### PR TITLE
nabd: turn off leds at the end of an animation

### DIFF
--- a/nabd/nabio_hw.py
+++ b/nabd/nabio_hw.py
@@ -73,6 +73,11 @@ class NabIOHW(NabIO):
                 index = (index + 1) % len(animation)
             else:
                 break
+        self.clear_info()
+
+    def clear_info(self):
+        for led in (Leds.LED_LEFT, Leds.LED_CENTER, Leds.LED_RIGHT):
+            self.leds.set1(led, 0, 0, 0)
 
     @staticmethod
     async def _wait_on_condvar(condvar, ms):


### PR DESCRIPTION
When an animation finishes, all animation related leds are turned off.
It avoids having remaining leds on when animations are disabled.

Fixes #76