### PR TITLE
Add Reboot and Shutdown buttons to web interface #15

### DIFF
--- a/nabd/nabd.py
+++ b/nabd/nabd.py
@@ -836,11 +836,9 @@ class Nabd:
             Nabd.SLEEP_EAR_POSITION, Nabd.SLEEP_EAR_POSITION
         )
         if doReboot:
-            # os.system("/sbin/reboot")
-            logging.debug("DO REBOOT")
+            os.system("/sbin/reboot")
         else:
-            # os.system("/sbin/halt")
-            logging.debug("DO SHUTDOWN")
+            os.system("/sbin/halt")
 
     def ears_callback(self, ear):
         if self.interactive_service_writer:

--- a/nabd/nabd.py
+++ b/nabd/nabd.py
@@ -836,9 +836,11 @@ class Nabd:
             Nabd.SLEEP_EAR_POSITION, Nabd.SLEEP_EAR_POSITION
         )
         if doReboot:
-            os.system("/sbin/reboot")
+            # os.system("/sbin/reboot")
+            logging.debug("DO REBOOT")
         else:
-            os.system("/sbin/halt")
+            # os.system("/sbin/halt")
+            logging.debug("DO SHUTDOWN")
 
     def ears_callback(self, ear):
         if self.interactive_service_writer:

--- a/nabd/nabd.py
+++ b/nabd/nabd.py
@@ -836,9 +836,15 @@ class Nabd:
             Nabd.SLEEP_EAR_POSITION, Nabd.SLEEP_EAR_POSITION
         )
         if doReboot:
-            os.system("/sbin/reboot")
+            await self._do_system_command("/sbin/reboot")
         else:
-            os.system("/sbin/halt")
+            await self._do_system_command("/sbin/halt")
+
+    async def _do_system_command(self, sytemCommandStr):
+        inTesting = os.path.basename(sys.argv[0]) in ("pytest", "py.test")
+        if not inTesting:
+            logging.debug(f"Initiating system command : {sytemCommandStr}")
+            os.system(sytemCommandStr)
 
     def ears_callback(self, ear):
         if self.interactive_service_writer:

--- a/nabweb/locale/fr_FR/LC_MESSAGES/django.po
+++ b/nabweb/locale/fr_FR/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-02-12 11:41+0100\n"
+"POT-Creation-Date: 2020-03-06 01:05+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,35 +17,35 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: settings.py:129
+#: settings.py:130
 msgid "French"
 msgstr "Français"
 
-#: settings.py:130
+#: settings.py:131
 msgid "German"
 msgstr "Allemand"
 
-#: settings.py:131
+#: settings.py:132
 msgid "U.S. English"
 msgstr "Anglais des États-Unis"
 
-#: settings.py:132
+#: settings.py:133
 msgid "British English"
 msgstr "Anglais britannique"
 
-#: settings.py:133
+#: settings.py:134
 msgid "Italian"
 msgstr "Italien"
 
-#: settings.py:134
+#: settings.py:135
 msgid "Spanish"
 msgstr "Espagnol"
 
-#: settings.py:135
+#: settings.py:136
 msgid "Japanese"
 msgstr "Japonais"
 
-#: settings.py:136
+#: settings.py:137
 msgid "Brazilian Portuguese"
 msgstr "Portugais brésilien"
 
@@ -71,7 +71,7 @@ msgstr "Services"
 
 #: templates/nabweb/_base.html:30 templates/nabweb/rfid/index.html:4
 #: templates/nabweb/rfid/index.html:26
-#: templates/nabweb/system-info/index.html:73
+#: templates/nabweb/system-info/index.html:92
 msgid "RFID"
 msgstr "RFID"
 
@@ -187,15 +187,15 @@ msgstr ""
 "remplacer?"
 
 #: templates/nabweb/rfid/index.html:16
-#: templates/nabweb/system-info/index.html:68
-#: templates/nabweb/system-info/index.html:74
+#: templates/nabweb/system-info/index.html:87
+#: templates/nabweb/system-info/index.html:93
 #: templates/nabweb/upgrade/index.html:30
 msgid "Yes"
 msgstr "Oui"
 
 #: templates/nabweb/rfid/index.html:17
-#: templates/nabweb/system-info/index.html:68
-#: templates/nabweb/system-info/index.html:74
+#: templates/nabweb/system-info/index.html:87
+#: templates/nabweb/system-info/index.html:93
 #: templates/nabweb/upgrade/index.html:31
 msgid "No"
 msgstr "Non"
@@ -370,47 +370,47 @@ msgstr "Jaune pur"
 msgid "Darker vivid orange"
 msgstr "Orange vif un peu plus foncé"
 
-#: templates/nabweb/rfid/index.html:101
+#: templates/nabweb/rfid/index.html:103
 msgid "Application"
 msgstr "Application"
 
-#: templates/nabweb/rfid/index.html:104
+#: templates/nabweb/rfid/index.html:106
 msgid "None"
 msgstr "Aucune"
 
-#: templates/nabweb/rfid/index.html:121
+#: templates/nabweb/rfid/index.html:123
 msgid "RFID is not available (no reader detected)"
 msgstr "Le RFID n'est pas disponible (aucun lecteur détecté)"
 
-#: templates/nabweb/rfid/index.html:127
+#: templates/nabweb/rfid/index.html:130 templates/nabweb/rfid/index.html:133
 msgid "Configure tag"
 msgstr "Configurer un tag"
 
-#: templates/nabweb/rfid/index.html:127
+#: templates/nabweb/rfid/index.html:130
 msgid "Configure another tag"
 msgstr "Configurer un autre tag"
 
-#: templates/nabweb/rfid/index.html:128
+#: templates/nabweb/rfid/index.html:131
 msgid "Write tag"
 msgstr "Écrire le tag"
 
-#: templates/nabweb/rfid/index.html:250
+#: templates/nabweb/rfid/index.html:257
 msgid "Supported (but read-only)"
 msgstr "Géré (mais en lecture seule)"
 
-#: templates/nabweb/rfid/index.html:252 templates/nabweb/rfid/index.html:256
+#: templates/nabweb/rfid/index.html:259 templates/nabweb/rfid/index.html:263
 msgid "Supported"
 msgstr "Géré"
 
-#: templates/nabweb/rfid/index.html:259
+#: templates/nabweb/rfid/index.html:266
 msgid "Supported (but with unknown data)"
 msgstr "Géré (mais avec des données inconnues)"
 
-#: templates/nabweb/rfid/index.html:263
+#: templates/nabweb/rfid/index.html:270
 msgid "Locked (cannot be used)"
 msgstr "Verrouillé (ne peut pas être utilisé)"
 
-#: templates/nabweb/rfid/index.html:265
+#: templates/nabweb/rfid/index.html:272
 msgid ""
 "Unsupported PICC (file a GitHub issue with UID to see if support can be "
 "added)"
@@ -418,12 +418,12 @@ msgstr ""
 "PICC non géré (créez un ticket sur GitHub avec le UID pour voir si cela peut "
 "se corriger)"
 
-#: templates/nabweb/rfid/index.html:323 templates/nabweb/rfid/index.html:391
+#: templates/nabweb/rfid/index.html:328 templates/nabweb/rfid/index.html:395
 msgid "Unknown response: "
 msgstr "Réponse inconnue: "
 
-#: templates/nabweb/rfid/index.html:329 templates/nabweb/rfid/index.html:364
-#: templates/nabweb/rfid/index.html:396
+#: templates/nabweb/rfid/index.html:333 templates/nabweb/rfid/index.html:368
+#: templates/nabweb/rfid/index.html:400
 msgid "An unknown server error occurred"
 msgstr "Une erreur serveur inconnue est survenue"
 
@@ -440,7 +440,7 @@ msgid "Version"
 msgstr "Version"
 
 #: templates/nabweb/system-info/index.html:16
-#: templates/nabweb/system-info/index.html:40
+#: templates/nabweb/system-info/index.html:59
 msgid "Uptime"
 msgstr "Levé depuis"
 
@@ -460,53 +460,89 @@ msgstr "Activé"
 msgid "Disabled"
 msgstr "Désactivé"
 
-#: templates/nabweb/system-info/index.html:29
+#: templates/nabweb/system-info/index.html:22
+msgid "Maintenance"
+msgstr "Maintenance"
+
+#: templates/nabweb/system-info/index.html:24
+msgid "Reboot"
+msgstr "Redémarrer"
+
+#: templates/nabweb/system-info/index.html:25
+msgid "Shutdown"
+msgstr "Arrêter"
+
+#: templates/nabweb/system-info/index.html:31
+msgid "Reboot has been initiated !"
+msgstr "Le redémarrage est en cours !"
+
+#: templates/nabweb/system-info/index.html:37
+msgid "Shutdown has been initiated !"
+msgstr "L'arrêt est en cours !"
+
+#: templates/nabweb/system-info/index.html:37
+msgid "Please wait at least 10 seconds before unplugging the power cable"
+msgstr "Veuillez attendre au moins 10 secondes avant de débrancher le cable d'alimentation"
+
+#: templates/nabweb/system-info/index.html:48
 msgid "Nabd daemon"
 msgstr "Processus Nabd"
 
-#: templates/nabweb/system-info/index.html:38
+#: templates/nabweb/system-info/index.html:57
 msgid "State"
 msgstr "État"
 
-#: templates/nabweb/system-info/index.html:42
+#: templates/nabweb/system-info/index.html:61
 msgid "Clients (including website)"
 msgstr "Clients (y compris ce site Web)"
 
-#: templates/nabweb/system-info/index.html:54
+#: templates/nabweb/system-info/index.html:73
 msgid "Hardware"
 msgstr "Matériel"
 
-#: templates/nabweb/system-info/index.html:63
+#: templates/nabweb/system-info/index.html:82
 msgid "Model"
 msgstr "Modèle"
 
-#: templates/nabweb/system-info/index.html:65
+#: templates/nabweb/system-info/index.html:84
 msgid "Sound card"
 msgstr "Carte son"
 
-#: templates/nabweb/system-info/index.html:67
+#: templates/nabweb/system-info/index.html:86
 msgid "Sound input"
 msgstr "Entrée son"
 
-#: templates/nabweb/system-info/index.html:69
+#: templates/nabweb/system-info/index.html:88
 msgid "Left ear"
 msgstr "Oreille gauche"
 
-#: templates/nabweb/system-info/index.html:71
+#: templates/nabweb/system-info/index.html:90
 msgid "Right ear"
 msgstr "Oreille droite"
 
-#: templates/nabweb/system-info/index.html:78
+#: templates/nabweb/system-info/index.html:97
 msgid "Hardware test"
 msgstr "Test matériel"
 
-#: templates/nabweb/system-info/index.html:80
+#: templates/nabweb/system-info/index.html:99
 msgid "LEDs"
 msgstr "LEDs"
 
-#: templates/nabweb/system-info/index.html:81
+#: templates/nabweb/system-info/index.html:100
 msgid "Ears"
 msgstr "Oreilles"
+
+#: templates/nabweb/system-info/index.html:133
+msgid "You are about to REBOOT the Raspberry Pi Linux system"
+msgstr "Vous êtes sur le point de REDEMARRER le système Linux du Raspberry Pi"
+
+#: templates/nabweb/system-info/index.html:135
+msgid "You are about to SHUTDOWN the Raspberry Pi Linux system"
+msgstr "Vous êtes sur le point d\\'ETEINDRE le système Linux du Raspberry Pi"
+
+#: templates/nabweb/system-info/index.html:137
+msgid "Are you sure ?"
+msgstr "Etes-vous sûr(e) ?"
 
 #: templates/nabweb/upgrade/_repository.html:9
 msgid "Up to date"
@@ -588,20 +624,20 @@ msgstr ""
 msgid "Current versions"
 msgstr "Version actuelle"
 
-#: templates/nabweb/upgrade/index.html:68
+#: templates/nabweb/upgrade/index.html:73
 msgid "Last check:"
 msgstr "Dernière vérification :"
 
-#: templates/nabweb/upgrade/index.html:68
+#: templates/nabweb/upgrade/index.html:73
 #, python-format
 msgid "%(last_check_since)s ago"
 msgstr "il y a %(last_check_since)s"
 
-#: templates/nabweb/upgrade/index.html:73
+#: templates/nabweb/upgrade/index.html:78
 msgid "Check now"
 msgstr "Vérifier maintenant"
 
-#: templates/nabweb/upgrade/index.html:74
+#: templates/nabweb/upgrade/index.html:79
 msgid "Upgrade now"
 msgstr "Mise à jour"
 

--- a/nabweb/locale/fr_FR/LC_MESSAGES/django.po
+++ b/nabweb/locale/fr_FR/LC_MESSAGES/django.po
@@ -538,7 +538,7 @@ msgstr "Vous êtes sur le point de REDEMARRER le système Linux du Raspberry Pi"
 
 #: templates/nabweb/system-info/index.html:135
 msgid "You are about to SHUTDOWN the Raspberry Pi Linux system"
-msgstr "Vous êtes sur le point d\\'ETEINDRE le système Linux du Raspberry Pi"
+msgstr "Vous êtes sur le point d'ETEINDRE le système Linux du Raspberry Pi"
 
 #: templates/nabweb/system-info/index.html:137
 msgid "Are you sure ?"

--- a/nabweb/templates/nabweb/system-info/index.html
+++ b/nabweb/templates/nabweb/system-info/index.html
@@ -129,6 +129,7 @@
       });
       $(".os-shutdown-button").each(function(i, btn) {
         $(btn).on("click", function() {
+            var popupMessage
             if ($(btn).attr("id") == 'button-reboot') {
               popupMessage = '{% trans "You are about to REBOOT the Raspberry Pi Linux system" %}'
             } else {

--- a/nabweb/templates/nabweb/system-info/index.html
+++ b/nabweb/templates/nabweb/system-info/index.html
@@ -18,6 +18,25 @@
             <dt class="col-sm-4"><a class="help-link" href="https://www.raspberrypi.org/documentation/remote-access/ssh/" >{% trans "SSH (Secure shell)" %}</a></dt>
             <dd class="col-sm-8">{% if os.ssh == "sshwarn" %}<span class="text-danger">{% trans "Enabled with default password" %}</span>{% else %}{% if os.ssh == "active" %}{% trans "Enabled" %}{% else %}{% trans "Disabled" %}{% endif %}{% endif %}</dd>
           </dl>
+          <dl class="row">
+            <dt class="col-sm-4">{% trans "Maintenance"%}</dt>
+            <dd class="col-sm-8">
+                <button id="button-reboot" data-shutdown-url="{% url 'nabweb.shutdown' mode='reboot' %}" class="btn btn-warning os-shutdown-button">{% trans "Reboot"%}<span class="spinner d-none"> <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span></span></button>
+                <button id="button-shutdown" data-shutdown-url="{% url 'nabweb.shutdown' mode='shutdown' %}" class="btn btn-danger os-shutdown-button">{% trans "Shutdown"%}<span class="spinner d-none"> <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span></span></button>
+            </dd>
+          </dl>
+          <dl class="row" id="rebootMessageRow" style="display:none">
+            <dt class="col-sm-4"></dt>
+            <dd class="col-sm-8">
+              <code>{% trans "Reboot has been initiated !"%}</code>
+            </dd>
+          </dl>
+          <dl class="row" id="shutdownMessageRow" style="display:none">
+            <dt class="col-sm-4"></dt>
+            <dd class="col-sm-8">
+              <code>{% trans "Shutdown has been initiated !"%}<BR>{% trans "Please wait at least 10 seconds before unplugging the power cable"%}</code>
+            </dd>
+          </dl>
         </div>
       </div>
     </div>
@@ -106,6 +125,42 @@
                 $(btn).find(".spinner").addClass("d-none");
               }
             });
+        });
+      });
+      $(".os-shutdown-button").each(function(i, btn) {
+        $(btn).on("click", function() {
+            if ($(btn).attr("id") == 'button-reboot') {
+              popupMessage = '{% trans "You are about to REBOOT the Raspberry Pi Linux system" %}'
+            } else {
+              popupMessage = '{% trans "You are about to SHUTDOWN the Raspberry Pi Linux system" %}'
+            }
+            if (confirm(popupMessage+'\n{% trans "Are you sure ?" %}')) {
+              if ($(btn).attr("id") == 'button-reboot') {
+                $("#rebootMessageRow").show();
+                $("#shutdownMessageRow").hide();                
+              } else {
+                $("#shutdownMessageRow").show();
+                $("#rebootMessageRow").hide();
+              }
+              $(btn).addClass("disabled");
+              $(btn).find(".spinner").removeClass("d-none");
+              $.ajax({
+                url: $(btn).data("shutdown-url"),
+                beforeSend: function (xhr, settings) {
+                  xhr.setRequestHeader("X-CSRFToken", "{{ csrf_token }}");
+                },
+                dataType: 'json',
+                type: "POST",
+                success: function (data) {
+                  $(btn).removeClass("disabled");
+                  $(btn).find(".spinner").addClass("d-none");
+                },
+                error: function (data) {
+                  $(btn).removeClass("disabled");
+                  $(btn).find(".spinner").addClass("d-none");
+                }
+              });
+            }
         });
       });
     });

--- a/nabweb/templates/nabweb/system-info/index.html
+++ b/nabweb/templates/nabweb/system-info/index.html
@@ -21,8 +21,8 @@
           <dl class="row">
             <dt class="col-sm-4">{% trans "Maintenance"%}</dt>
             <dd class="col-sm-8">
-                <button id="button-reboot" data-shutdown-url="{% url 'nabweb.shutdown' mode='reboot' %}" class="btn btn-warning os-shutdown-button">{% trans "Reboot"%}<span class="spinner d-none"> <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span></span></button>
-                <button id="button-shutdown" data-shutdown-url="{% url 'nabweb.shutdown' mode='shutdown' %}" class="btn btn-danger os-shutdown-button">{% trans "Shutdown"%}<span class="spinner d-none"> <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span></span></button>
+                <button id="button-reboot" data-toggle="modal" data-target="#confirm-reboot" data-shutdown-url="{% url 'nabweb.shutdown' mode='reboot' %}" class="btn btn-warning">{% trans "Reboot"%}<span class="spinner d-none"> <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span></span></button>
+                <button id="button-shutdown" data-toggle="modal" data-target="#confirm-shutdown" data-shutdown-url="{% url 'nabweb.shutdown' mode='shutdown' %}" class="btn btn-danger">{% trans "Shutdown"%}<span class="spinner d-none"> <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span></span></button>
             </dd>
           </dl>
           <dl class="row" id="rebootMessageRow" style="display:none">
@@ -103,6 +103,44 @@
       </div>
     </div>
   </div>
+  <div class="modal fade" id="confirm-reboot" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">{% trans "Reboot" %}</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          {% trans "You are about to REBOOT the Raspberry Pi Linux system" %}<BR><BR>{% trans "Are you sure ?" %}
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">{% trans "Cancel" %}</button>
+          <button type="button" id="button-reboot-confirm" class="btn btn-primary os-shutdown-button" data-dismiss="modal">{% trans "Reboot" %}</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="modal fade" id="confirm-shutdown" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">{% trans "Shutdown" %}</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          {% trans "You are about to SHUTDOWN the Raspberry Pi Linux system" %}<BR><BR>{% trans "Are you sure ?" %}
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">{% trans "Cancel" %}</button>
+          <button type="button" id="button-shutdown-confirm" class="btn btn-primary os-shutdown-button" data-dismiss="modal">{% trans "Shutdown" %}</button>
+        </div>
+      </div>
+    </div>
+  </div>  
   <script type="text/javascript">
     $(function() {
       $(".hardware-test-button").each(function(i, btn) {
@@ -129,39 +167,33 @@
       });
       $(".os-shutdown-button").each(function(i, btn) {
         $(btn).on("click", function() {
-            var popupMessage
-            if ($(btn).attr("id") == 'button-reboot') {
-              popupMessage = '{% trans "You are about to REBOOT the Raspberry Pi Linux system" %}'
+            if ($(btn).attr("id") == 'button-reboot-confirm') {
+              var origButton = $("#button-reboot")
+              $("#rebootMessageRow").show();
+              $("#shutdownMessageRow").hide();                
             } else {
-              popupMessage = '{% trans "You are about to SHUTDOWN the Raspberry Pi Linux system" %}'
+              var origButton = $("#button-shutdown")
+              $("#shutdownMessageRow").show();
+              $("#rebootMessageRow").hide();
             }
-            if (confirm(popupMessage+'\n{% trans "Are you sure ?" %}')) {
-              if ($(btn).attr("id") == 'button-reboot') {
-                $("#rebootMessageRow").show();
-                $("#shutdownMessageRow").hide();                
-              } else {
-                $("#shutdownMessageRow").show();
-                $("#rebootMessageRow").hide();
+            origButton.addClass("disabled");
+            origButton.find(".spinner").removeClass("d-none");
+            $.ajax({
+              url: origButton.data("shutdown-url"),
+              beforeSend: function (xhr, settings) {
+                xhr.setRequestHeader("X-CSRFToken", "{{ csrf_token }}");
+              },
+              dataType: 'json',
+              type: "POST",
+              success: function (data) {
+                origButton.removeClass("disabled");
+                origButton.find(".spinner").addClass("d-none");
+              },
+              error: function (data) {
+                origButton.removeClass("disabled");
+                origButton.find(".spinner").addClass("d-none");
               }
-              $(btn).addClass("disabled");
-              $(btn).find(".spinner").removeClass("d-none");
-              $.ajax({
-                url: $(btn).data("shutdown-url"),
-                beforeSend: function (xhr, settings) {
-                  xhr.setRequestHeader("X-CSRFToken", "{{ csrf_token }}");
-                },
-                dataType: 'json',
-                type: "POST",
-                success: function (data) {
-                  $(btn).removeClass("disabled");
-                  $(btn).find(".spinner").addClass("d-none");
-                },
-                error: function (data) {
-                  $(btn).removeClass("disabled");
-                  $(btn).find(".spinner").addClass("d-none");
-                }
-              });
-            }
+            });
         });
       });
     });

--- a/nabweb/urls.py
+++ b/nabweb/urls.py
@@ -20,6 +20,7 @@ from .views import NabWebRfidView, NabWebRfidReadView, NabWebRfidWriteView
 from .views import NabWebUpgradeView, NabWebUpgradeStatusView
 from .views import NabWebUpgradeNowView, NabWebUpgradeCheckNowView
 from .views import NabWebUpgradeRepositoryInfoView, NabWebHardwareTestView
+from .views import NabWebShutdownView
 
 urlpatterns = [
     path("", NabWebView.as_view()),
@@ -33,6 +34,11 @@ urlpatterns = [
         name="nabweb.test",
     ),
     path("system-info/", NabWebSytemInfoView.as_view()),
+    path(
+        "system-info/shutdown/<mode>",
+        NabWebShutdownView.as_view(),
+        name="nabweb.shutdown",
+    ),
     path("upgrade/", NabWebUpgradeView.as_view()),
     path(
         "upgrade/info/<repository>",

--- a/nabweb/views.py
+++ b/nabweb/views.py
@@ -653,7 +653,9 @@ class NabWebShutdownView(View):
 
     async def _do_os_shutdown(self, reader, writer, mode):
         try:
-            packet = f'{{"type":"shutdown","mode":"{mode}","request_id":"shutdown"}}\r\n'
+            # packet = f'{{"type":"shutdown","mode":"{mode}","request_id":"shutdown"}}\r\n'
+            packet = f'{{"type":"shutdown","mode":"{mode}",' \
+                     f'"request_id":"shutdown"}}\r\n'  
             writer.write(packet.encode("utf8"))
             await writer.drain()
             while True:

--- a/nabweb/views.py
+++ b/nabweb/views.py
@@ -644,6 +644,7 @@ class NabWebUpgradeNowView(View):
             }
         )
 
+
 class NabWebShutdownView(View):
     async def os_shutdown(self, mode):
         return await NabdConnection.transaction(self._do_os_shutdown, mode)
@@ -666,7 +667,7 @@ class NabWebShutdownView(View):
         except asyncio.TimeoutError as err:
             return {
                 "status": "error",
-                "message": "Communication with Nabd timed out (running shutdown)",
+                "message": "Communication with Nabd timed out (shutdown)",
             }
 
     def post(self, request, *args, **kwargs):

--- a/nabweb/views.py
+++ b/nabweb/views.py
@@ -644,7 +644,6 @@ class NabWebUpgradeNowView(View):
             }
         )
 
-
 class NabWebShutdownView(View):
     async def os_shutdown(self, mode):
         return await NabdConnection.transaction(self._do_os_shutdown, mode)

--- a/nabweb/views.py
+++ b/nabweb/views.py
@@ -653,9 +653,8 @@ class NabWebShutdownView(View):
 
     async def _do_os_shutdown(self, reader, writer, mode):
         try:
-            # packet = f'{{"type":"shutdown","mode":"{mode}","request_id":"shutdown"}}\r\n'
             packet = f'{{"type":"shutdown","mode":"{mode}",' \
-                     f'"request_id":"shutdown"}}\r\n'  
+                     f'"request_id":"shutdown"}}\r\n'
             writer.write(packet.encode("utf8"))
             await writer.drain()
             while True:


### PR DESCRIPTION
Hi,

This is my proposal for adding shutdown and reboot buttons to the web interface,
in the system information page.

I made the choice of adding a new shutdown method directly in the API of nabd,
to re-use the shutdown function already existing and doing everything in one single place...

Please tell me what do you think of it and if something need to be modified :)

Related to #15 