### PR TITLE
Fix #103: Mastodon settings disappear if address is invalid

### DIFF
--- a/nabmastodond/locale/fr_FR/LC_MESSAGES/django.po
+++ b/nabmastodond/locale/fr_FR/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-11 16:52+0200\n"
+"POT-Creation-Date: 2020-06-23 11:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -38,6 +38,10 @@ msgstr "Âme sœur"
 #: templates/nabmastodond/settings.html:25
 msgid "Friend address"
 msgstr "Adresse de votre ami(e)"
+
+#: templates/nabmastodond/settings.html:25
+msgid "e.g. name@instance.tld"
+msgstr "ex: nom@instance.tld"
 
 #: templates/nabmastodond/settings.html:27
 msgid "Propose"
@@ -183,9 +187,9 @@ msgid ""
 "Mastodon instance, you can find a directory of Mastodon instances <a href="
 "\"https://joinmastodon.org/\" target=\"_blank\">here</a>."
 msgstr ""
-"Tout d'abord,<strong> créez un compte pour votre Nabaztag</strong> sur une instance "
-"Mastodon, vous trouverez <a href=\"https://joinmastodon.org/\" target="
-"\"_blank\">ici</a> un répertoire des instances."
+"Tout d'abord,<strong> créez un compte pour votre Nabaztag</strong> sur une "
+"instance Mastodon, vous trouverez <a href=\"https://joinmastodon.org/\" "
+"target=\"_blank\">ici</a> un répertoire des instances."
 
 #: templates/nabmastodond/settings.html:260
 msgid ""

--- a/nabmastodond/templates/nabmastodond/settings.html
+++ b/nabmastodond/templates/nabmastodond/settings.html
@@ -22,7 +22,7 @@
                 <div class="input-group-prepend">
                   <span class="input-group-text">{% trans "Kindred soul" %}</span>
                 </div>
-                <input name="spouse" type="text" class="form-control" aria-label="{% trans "Friend address" %}" value="">
+                <input name="spouse" type="text" class="form-control" pattern="@?[^@]+@[^@]+" aria-label="{% trans "Friend address" %}" placeholder="{% trans "e.g. name@instance.tld" %}" value="">
                 <div class="input-group-append">
                   <button type="submit" class="btn btn-primary propose-button">{% trans "Propose" %}</button>
                 </div>

--- a/nabmastodond/templatetags/mastodon_tags.py
+++ b/nabmastodond/templatetags/mastodon_tags.py
@@ -7,5 +7,20 @@ register = template.Library()
 @register.filter
 @stringfilter
 def to_profile_url(value):
-    [username, instance] = value.split('@')
-    return 'https://' + instance + '/@' + username
+    username = ""
+    instance = ""
+    parts = value.split("@")
+    if len(parts) == 2:
+        username = parts[0]
+        instance = parts[1]
+    elif len(parts) == 3 and parts[0] == "":
+        username = parts[1]
+        instance = parts[2]
+    else:
+        raise ValueError(
+            'Invalid Mastodon identifier "'
+            + value
+            + '". Should be "name@instance.tld" or "@name@instance.tld"'
+        )
+
+    return "https://" + instance + "/@" + username

--- a/nabmastodond/tests/nabmastodond_mastodon_tags_test.py
+++ b/nabmastodond/tests/nabmastodond_mastodon_tags_test.py
@@ -1,0 +1,36 @@
+from django.test import SimpleTestCase
+from django.template import Context, Template
+
+
+class ToProfileUrl1AtTagTest(SimpleTestCase):
+    def test_rendered(self):
+        context = Context()
+        template_to_render = Template(
+            "{% load mastodon_tags %}"
+            '{{ "name@instance.tld" | to_profile_url }}'
+        )
+        rendered_template = template_to_render.render(context)
+        self.assertEqual("https://instance.tld/@name", rendered_template)
+
+
+class ToProfileUrl2AtTagTest(SimpleTestCase):
+    def test_rendered(self):
+        context = Context()
+        template_to_render = Template(
+            "{% load mastodon_tags %}"
+            '{{ "@name@instance.tld" | to_profile_url }}'
+        )
+        rendered_template = template_to_render.render(context)
+        self.assertEqual("https://instance.tld/@name", rendered_template)
+
+
+class ToProfileUrl3AtTagTest(SimpleTestCase):
+    def test_rendered(self):
+        with self.assertRaises(ValueError):
+            context = Context()
+            template_to_render = Template(
+                "{% load mastodon_tags %}"
+                '{{ "@name@instance.tld@" | to_profile_url }}'
+            )
+            rendered_template = template_to_render.render(context)
+            self.assertEqual("https://instance.tld/@name", rendered_template)


### PR DESCRIPTION
The code did not cater for Mastodon addresses provided with a leading `@` and
was crashing as a result. Fixed by:
- Updating the Mastodon template tag to handle a leading `@` + added a test for
  it. This should fix the problem for users who already have paired with a
  rabbit with an "invalid" address in the database
- Updating the HTML template with a `pattern` attribute to enforce a valid
  Mastodon ID format (support both with and without a leading `@`). Also added
  a placeholder to guide the user