### PR TITLE
Add optional 'event' slot to 'ears' packet type

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -327,9 +327,8 @@ if [ ! -f "/etc/logrotate.d/pynab" ]; then
 	 }
 	END
 	sudo mv /tmp/pynab /etc/logrotate.d/pynab
-	sudo touch /tmp/pynab.upgrade.reboot
 fi
-
+sudo chown root:root /etc/logrotate.d/pynab
 
 # Fix Advertise rabbit on local network #141 
 if [ ! -f "/etc/avahi/services/pynab.service" ]; then
@@ -350,7 +349,6 @@ if [ ! -f "/etc/avahi/services/pynab.service" ]; then
 	</service-group>
 	END
 	sudo mv /tmp/pynab.service /etc/avahi/services/pynab.service
-	sudo touch /tmp/pynab.upgrade.reboot
 
 fi
 
@@ -372,7 +370,6 @@ if [ ! -f "/etc/avahi/services/nabblocky.service" ]; then
 	</service-group>
 	END
 	sudo mv /tmp/nabblocky.service /etc/avahi/services/nabblocky.service
-	sudo touch /tmp/pynab.upgrade.reboot
 
 fi
 
@@ -386,6 +383,7 @@ else
     if [ $upgrade -eq 1 ]; then
       echo "Restarting services - 13/14" > /tmp/pynab.upgrade
     fi
+    sudo systemctl restart logrotate.service
     sudo systemctl start nabd.socket
     sudo systemctl start nabd.service
 

--- a/nabd/nabd.py
+++ b/nabd/nabd.py
@@ -332,6 +332,12 @@ class Nabd:
         if "right" in packet:
             self.ears["right"] = packet["right"]
         if self.state == State.IDLE:
+            if "event" in packet and packet["event"]:
+                # Simulate an ears_event
+                self.broadcast_event(
+                    "ears",
+                    {"type": "ears_event", "left": self.ears["left"], "right": self.ears["right"]},
+                )
             await self.nabio.move_ears(self.ears["left"], self.ears["right"])
         self.write_response_packet(packet, {"status": "ok"}, writer)
 


### PR DESCRIPTION
Resolves  https://github.com/nabaztag2018/pynab/issues/147
Used to trigger ears pairing by sending such a packet to local rabbit, without having to move its ears by hand
(if 'event' is true, nabd will simulate an 'ears_event' with new ears position).