### PR TITLE
Fix install of avahi and logrotate configuration files for pynab

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -328,9 +328,8 @@ if [ ! -f "/etc/logrotate.d/pynab" ]; then
 	 }
 	END
 	sudo mv /tmp/pynab /etc/logrotate.d/pynab
-	sudo touch /tmp/pynab.upgrade.reboot
 fi
-
+sudo chown root:root /etc/logrotate.d/pynab
 
 # Fix Advertise rabbit on local network #141 
 if [ ! -f "/etc/avahi/services/pynab.service" ]; then
@@ -351,7 +350,6 @@ if [ ! -f "/etc/avahi/services/pynab.service" ]; then
 	</service-group>
 	END
 	sudo mv /tmp/pynab.service /etc/avahi/services/pynab.service
-	sudo touch /tmp/pynab.upgrade.reboot
 
 fi
 
@@ -373,7 +371,6 @@ if [ ! -f "/etc/avahi/services/nabblocky.service" ]; then
 	</service-group>
 	END
 	sudo mv /tmp/nabblocky.service /etc/avahi/services/nabblocky.service
-	sudo touch /tmp/pynab.upgrade.reboot
 
 fi
 
@@ -387,6 +384,7 @@ else
     if [ $upgrade -eq 1 ]; then
       echo "Restarting services - 13/14" > /tmp/pynab.upgrade
     fi
+    sudo systemctl restart logrotate.service
     sudo systemctl start nabd.socket
     sudo systemctl start nabd.service
 


### PR DESCRIPTION
Resolves #159
In install.sh script:
installed /etc/logrotate.d/pynab file chown'd to root;
no reboot needed to take into acount new avahi and logrotate conf files: only need to restart logrotate service.