### PR TITLE
nabweb dropdown buttons: fix select list width

### DIFF
--- a/nabweb/static/nabweb/css/nabweb.css
+++ b/nabweb/static/nabweb/css/nabweb.css
@@ -15,3 +15,8 @@ a.help-link:hover {
   color: inherit;
   text-decoration: inherit;
 }
+
+/* select elements */
+select {
+  width: 100%;
+}


### PR DESCRIPTION
Resolves #150 .
Fix dropdown buttons (select list) width on small screens (phones/tablets).
Tested wth Safari and Firefox on iOS 14.