### PR TITLE
Set .gitignore to ignore nabblockly subdirectory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ venv.bak/
 
 # tmp
 tmp/
+
+# nabblockly subdirectory
+/nabblockly/


### PR DESCRIPTION
Avoid having `nabblockly` subdirectory always showing up in untracked files of the `pynab` repository.