### PR TITLE
Docker Compose based development environment

### DIFF
--- a/Docker/Docker.md
+++ b/Docker/Docker.md
@@ -1,0 +1,73 @@
+# Docker-based development environment
+
+This folder contains a Docker Compose environment to develop for pynab on a PC,
+rather than on the Raspberry Pi. It can only run the web interface (nabweb) for
+now but should be extensible to allow running all services ultimately.
+
+## How to (tl;dr)
+
+All commands must be run inside the `Docker/` folder.
+
+Start everything:
+
+```
+docker-compose up --build -d
+# Visit http://localhost:8000
+```
+
+View logs:
+
+```
+docker-compose logs -f
+```
+
+Stop everything:
+
+```
+docker-compose down
+```
+
+## Details
+
+### Containers
+
+The following containers are started (See
+[docker-compose.yml](docker-compose.yml))
+- `db`: PostgreSQL database, with automatic creation of the `pynab` user and
+  database.
+- `migrate`: Runs `manage.py migrate` to apply DB migrations.
+- `nabweb`: Web interface WSGI.
+- `nabmastodond`: Example of running a separate service, Mastodon in that case.
+  Currently it stops immediately as there's no `nabd` daemon to talk to, yet.
+
+`db` is using the official PostgreSQL image. All other containers are using a
+custom image based of the official Python image (See
+[nab/Dockerfile](nab/Dockerfile)).
+
+### Access to the database
+
+All containers access the database via a Unix socket inside a shared volume
+(mounted in `/var/run/postgresql/`). This is atypical (usually services would
+connect to the DB via the network), but it allows the environment to work
+without having to modify pynab which assumes socket-based DB communication.
+
+### Host volume
+
+The pynab project folder is shared via a host volume, mounted in
+`/home/pi/pynab` inside the containers to replicate the Raspberry Pi location.
+
+### Synchronization between containers
+
+Containers have dependencies: The individual services cannot start until the
+database is initialized, and the migration container cannot start until
+PostgreSQL is up and running and the `pynab` database exists.
+
+Synchronization is currently crudely achieved via shell scripts:
+- `wait-for-db.sh`: Waits for the database to be available. This wait for the
+  `pynab` database to be available, as just waiting for PostgreSQL to be running
+  is not enough.
+- `wait-for-file.sh`: Waits for a specific file to appear. This is used by the
+  migration container which writes a file when the migrations are completed to
+  let the services now the database is ready. The file is written under
+  `/var/run/postgresql/`, a shared folder across containers. Unfortunately all
+  containers must run as root in order to be able to write into this folder.

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -1,0 +1,48 @@
+version: '3.8'
+services:
+    # PostgreSQL database
+    db:
+        image: postgres:11-alpine
+        environment:
+            POSTGRES_PASSWORD: pynab
+            POSTGRES_USER: pynab
+        volumes:
+            - var-lib-postgresql-data:/var/lib/postgresql/data
+            - var-run-postgresql:/var/run/postgresql
+    # Once off container to run the DB migrations
+    migrate:
+        build: ./nab
+        volumes:
+            - ../:/home/pi/pynab
+            - var-run-postgresql:/var/run/postgresql
+        depends_on:
+            - db
+        command: ["/bin/bash", "/usr/local/bin/run-migrate.sh"]
+    nabweb:
+        build: ./nab
+        volumes:
+            - ../:/home/pi/pynab
+            - var-run-postgresql:/var/run/postgresql
+        depends_on:
+            - db
+            - migrate
+        command: ["/bin/sh", "-c", "/home/pi/venv/bin/gunicorn --timeout 60 -b 0.0.0.0 nabweb.wsgi"]
+        ports:
+            - 8000:8000
+    # FIXME: nabmastodond will stop immediately because there's no nabd to connect to
+    # but at least it starts correctly, as a proof of concept
+    nabmastodond:
+        build: ./nab
+        volumes:
+            - ../:/home/pi/pynab
+            - var-run-postgresql:/var/run/postgresql
+        depends_on:
+            - db
+            - migrate
+        command: ["/bin/bash", "/usr/local/bin/run-service.sh", "nabmastodond.nabmastodond"]
+
+volumes:
+    # Share the PostgreSQL socket between containers
+    var-run-postgresql:
+    # Persist the PostgreSQL data across restarts
+    var-lib-postgresql-data:

--- a/Docker/nab/Dockerfile
+++ b/Docker/nab/Dockerfile
@@ -1,0 +1,43 @@
+FROM python:3.7-buster
+
+RUN apt-get update && apt-get install -y \
+    postgresql-client \
+    libasound2-dev \
+    sudo
+
+COPY *.sh /usr/local/bin/
+
+RUN echo "pi ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/010_pi-nopasswd 
+
+# Fake rpi-issue file used by nabweb
+RUN echo "Raspberry Pi reference 1970-01-01" > /etc/rpi-issue
+
+# Fake nabd systemd service file used to retrieve the working directory
+RUN echo "WorkingDirectory=/home/pi/pynab" > /lib/systemd/system/nabd.service
+
+# Make /var/log/ writable for service log files, /run for PID files
+RUN chmod a+w /var/log /run
+
+RUN groupadd -g 1000 pi
+RUN useradd -u 1000 -m pi -g pi -s /bin/bash
+
+# FIXME: Cannot run as non-root user, as we need to write a file in
+# /var/run/postgresql to indicate that DB migrations have completed
+# Need to find a better way to notify the containers
+
+# USER pi
+
+RUN mkdir -p /home/pi/pynab
+
+WORKDIR /home/pi/pynab
+
+ENV VIRTUAL_ENV=/home/pi/venv
+RUN python3.7 -m venv ${VIRTUAL_ENV}
+ENV PATH=${VIRTUAL_ENV}/bin:${PATH}
+
+COPY ./requirements_docker.txt /tmp
+RUN ${VIRTUAL_ENV}/bin/pip install -r /tmp/requirements_docker.txt
+
+ENV PYNAB_DEVELOPMENT=true
+
+EXPOSE 8000

--- a/Docker/nab/requirements_docker.txt
+++ b/Docker/nab/requirements_docker.txt
@@ -1,0 +1,84 @@
+# Docker-specific version of requirements.txt
+# Excludes ARM specific packages
+
+# Direct dependencies & pre-built binaries
+wheel
+black==19.10b0
+Django==3.0.14
+gunicorn==20.0.4
+lockfile==0.12.2
+Mastodon.py==1.5.0
+mpg123==0.4
+psycopg2-binary==2.8.4
+pytest-django==3.7.0
+pytest-pep8==1.0.6
+pytest==5.3.1
+asynctest==0.13.0
+coverage==5.0.3
+pyalsaaudio==0.8.4; sys_platform == 'linux'
+rpi-ws281x==4.2.2; sys_platform == 'linux' and 'armv6l' in platform_machine
+RPi.GPIO==0.7.0; sys_platform == 'linux' and 'armv6l' in platform_machine
+https://github.com/pguyot/py-kaldi-asr/releases/download/v0.5.2/Cython-0.29.10-cp37-cp37m-linux_armv6l.whl; sys_platform == 'linux' and 'armv6l' in platform_machine and python_version == '3.7'
+Cython==0.29.10; sys_platform != 'linux' or 'armv6l' not in platform_machine or python_version != '3.7'
+https://github.com/pguyot/py-kaldi-asr/releases/download/v0.5.3/py_kaldi_asr-0.5.3-cp37-cp37m-linux_armv6l.whl; sys_platform == 'linux' and 'armv6l' in platform_machine and python_version == '3.7'
+# git+https://github.com/pguyot/py-kaldi-asr@v0.5.3; sys_platform != 'linux' or 'armv6l' not in platform_machine or python_version != '3.7'
+https://github.com/pguyot/snips-nlu/releases/download/0.20.2/snips_nlu-0.20.2-py3-none-any.whl
+https://github.com/pguyot/snips-nlu-parsers/releases/download/v0.4.3/snips_nlu_parsers-0.4.3-cp37-cp37m-linux_armv6l.whl; sys_platform == 'linux' and 'armv6l' in platform_machine and python_version == '3.7'
+snips-nlu-parsers==0.4.3; sys_platform != 'linux' or 'armv6l' not in platform_machine or python_version != '3.7'
+https://github.com/pguyot/snips-nlu-utils/releases/download/v0.9.1/snips_nlu_utils-0.9.1-cp37-cp37m-linux_armv6l.whl; sys_platform == 'linux' and 'armv6l' in platform_machine and python_version == '3.7'
+snips-nlu-utils==0.9.1; sys_platform != 'linux' or 'armv6l' not in platform_machine or python_version != '3.7'
+https://files.pythonhosted.org/packages/b4/e6/f33077deb4aa1d4b79cb392887bc1de4fd0dab324c5923323e5bc0ad55d1/meteofrance_api-0.1.1-py3-none-any.whl
+
+# Indirect frozen dependencies
+apipkg==1.5
+appdirs==1.4.3
+asgiref==3.2.3
+atomicwrites==1.3.0
+attrs==19.3.0
+beautifulsoup4==4.8.1
+blurhash==1.1.4
+certifi==2019.11.28
+chardet==3.0.4
+Click==7.0
+decorator==4.4.1
+deprecation==2.0.7
+docopt==0.6.2
+execnet==1.7.1
+future==0.17.1
+idna==2.8
+importlib-metadata==1.3.0
+joblib==0.14.1
+more-itertools==8.0.2
+num2words==0.5.10
+numpy==1.20.2
+packaging==19.2
+pathspec==0.6.0
+pep8==1.7.1
+plac==1.1.3
+pluggy==0.13.1
+py==1.10.0
+pyaml==19.12.0
+pycodestyle==2.5.0
+pyparsing==2.4.5
+pytest-cache==1.0
+python-crfsuite==0.9.6
+python-dateutil==2.8.1
+python-magic==0.4.15
+pytz==2020.1
+PyYAML==5.4
+regex==2019.12.9
+requests==2.24.0
+scipy==1.6.2
+scikit-learn==0.22.2.post1
+semantic-version==2.8.3
+six==1.13.0
+sklearn-crfsuite==0.3.6
+soupsieve==1.9.5
+sqlparse==0.3.0
+tabulate==0.8.6
+toml==0.10.0
+tqdm==4.40.2
+typed-ast==1.4.0
+urllib3==1.25.8
+wcwidth==0.1.7
+zipp==0.6.0

--- a/Docker/nab/run-migrate.sh
+++ b/Docker/nab/run-migrate.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# -
+# Wait for the DB to be accessible and run the DB migrations
+set -e
+
+/bin/bash /usr/local/bin/wait-for-db.sh
+RC=$?
+
+if [ ! ${RC} -eq 0 ]; then
+    echo "Unable to access database, aborting."
+    exit 1
+fi
+
+echo "Running DB migrations"
+/home/pi/venv/bin/python3 /home/pi/pynab/manage.py migrate
+
+echo "Add migration completion marker file"
+touch /var/run/postgresql/migrate.completed

--- a/Docker/nab/run-service.sh
+++ b/Docker/nab/run-service.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# -
+# Wait for the DB migrations to complete and run a Python service
+set -e
+
+SERVICE=$1
+if [ "${SERVICE}" == "" ]; then
+    echo "Usage: $0 <service-name>"
+    echo "e.g.: $0 nabmastodond.nabmastodond"
+    exit 1
+fi
+
+# Wait for migrations to complete
+/bin/bash /usr/local/bin/wait-for-file.sh /var/run/postgresql/migrate.completed
+RC=$?
+
+if [ ! ${RC} -eq 0 ]; then
+    echo "Timeout waiting for migrations to complete, aborting."
+    exit 1
+fi
+
+echo "Running ${SERVICE}"
+exec /home/pi/venv/bin/python3 -m ${SERVICE}

--- a/Docker/nab/wait-for-db.sh
+++ b/Docker/nab/wait-for-db.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# -
+# Wait for the database to be accessible
+set -e
+
+RETRIES=5
+
+until psql -U pynab -d pynab -c "select 1" > /dev/null 2>&1 || [ ${RETRIES} -eq 0 ]; do
+    echo "Waiting for pynab DB to be ready, $((RETRIES--)) remaining attempts..."
+    sleep 1
+done
+
+psql -U pynab -d pynab -c "select 1" > /dev/null 2>&1
+exit $?

--- a/Docker/nab/wait-for-file.sh
+++ b/Docker/nab/wait-for-file.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# -
+# Wait for a file to appear
+set -e
+
+RETRIES=5
+
+FILE=$1
+if [ "${FILE}" == "" ]; then
+    echo "Usage: $0 </path/to/file>"
+    exit 1
+fi
+
+until [ -f ${FILE} ] || [ ${RETRIES} -eq 0 ]; do
+    echo "Waiting for ${FILE} to appear, $((RETRIES--)) remaining attempts..."
+    sleep 1
+done
+
+test -f ${FILE}
+exit $?

--- a/nabweb/urls.py
+++ b/nabweb/urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+import os
 from django.apps import apps
 from django.urls import path, include
 from .views import NabWebView, NabWebServicesView, NabWebSytemInfoView
@@ -61,6 +62,12 @@ urlpatterns = [
         name="nabweb.upgrade.checknow",
     ),
 ]
+
+if os.getenv('PYNAB_DEVELOPMENT') is not None:
+    # Development environment does not use nginx, serve
+    # static files directly
+    from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+    urlpatterns += staticfiles_urlpatterns()
 
 # Service URLs added automatically
 for config in apps.get_app_configs():

--- a/nabweb/views.py
+++ b/nabweb/views.py
@@ -345,8 +345,11 @@ class NabWebSytemInfoView(BaseView):
         }
 
     def get_pi_info(self):
-        with open("/proc/device-tree/model") as model_f:
-            model = model_f.readline()
+        try:
+            with open("/proc/device-tree/model") as model_f:
+                model = model_f.readline()
+        except (FileNotFoundError):
+            model = "unknown"
         return {"model": model}
 
     def get_context(self):


### PR DESCRIPTION
Use Docker Compose to run services locally and develop on a standard PC
rather than the Raspberry Pi via SSH, and avoiding the need for a test
and a prod rabbit. See `Docker.md` for details.

Some things are not working yet and will be addressed at a later stage:
- `nabd` is not available (Relies on Pi-specific hardware), meaning all
services that depend on it will not work. The plan is to write a fake
`nabd` daemon to fill the gap.
- Some pages of the web interfaces are not working correctly (for
example the Upgrade section). They probably make assumptions on the
environment that are not met by the Docker containers. It should be
fixable.

An alternative requirements file is used, currently not including the
dependencies that are harder to get for x86 (Kaldi ASR...). This will
need to get fixed at some point to get all services running.

Most of this PR are new files, the only practical changes are:
- Enable Gunicorn to serve static files on nabweb when the development
environment is used (based on an environment variable), as it doesn't
use Nginx for simplicity sake
- Small error handling change when the Raspberry Pi model cannot be read
from `/proc`.

This is just a starting point at this stage, but it already allows
hacking on the web interface.