### PR TITLE
nabweb 'Upgrade' page: give more precise 'Version' information.

### DIFF
--- a/nabweb/views.py
+++ b/nabweb/views.py
@@ -507,8 +507,7 @@ class GitInfo:
         )
         info["tag"] = (
             os.popen(
-                f"cd {repo_dir} && "
-                "sudo -u pi git describe --exact-match --tags"
+                f"cd {repo_dir} && " "sudo -u pi git describe --long --tags"
             )
             .read()
             .strip()


### PR DESCRIPTION
Use `git describe --long --tags`rather than `git describe --exact-match --tags`.