### PR TITLE
Next step in Docker-based development environment

### DIFF
--- a/Docker/Docker.md
+++ b/Docker/Docker.md
@@ -1,8 +1,7 @@
 # Docker-based development environment
 
 This folder contains a Docker Compose environment to develop for pynab on a PC,
-rather than on the Raspberry Pi. It can only run the web interface (nabweb) for
-now but should be extensible to allow running all services ultimately.
+rather than on the Raspberry Pi.
 
 ## How to (tl;dr)
 
@@ -37,12 +36,18 @@ The following containers are started (See
   database.
 - `migrate`: Runs `manage.py migrate` to apply DB migrations.
 - `nabweb`: Web interface WSGI.
-- `nabmastodond`: Example of running a separate service, Mastodon in that case.
-  Currently it stops immediately as there's no `nabd` daemon to talk to, yet.
+- `nab*d`: One container for each service.
+- `nabdevd`: A dummy nabd replacement, since all services need to talk to nabd
+  but it cannot run without the real hardware.
 
-`db` is using the official PostgreSQL image. All other containers are using a
-custom image based of the official Python image (See
-[nab/Dockerfile](nab/Dockerfile)).
+`db` is using the official PostgreSQL image. `nabdevd` is using a publicly
+available custom container. All other containers are using a custom image based
+on the official Python image (See [nab/Dockerfile](nab/Dockerfile)).
+
+The dummy nabd daemon is a
+[separate open-source project](https://gitlab.com/nguillaumin/nabdevd). It's
+quite minimal for now but will be extended to simulate as many functions
+provided by nabd as possible.
 
 ### Access to the database
 

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -18,6 +18,10 @@ services:
         depends_on:
             - db
         command: ["/bin/bash", "/usr/local/bin/run-migrate.sh"]
+    nabdevd:
+        image: registry.gitlab.com/nguillaumin/nabdevd:latest
+        ports:
+            - 3000:3000
     nabweb:
         build: ./nab
         volumes:
@@ -26,11 +30,80 @@ services:
         depends_on:
             - db
             - migrate
+            - nabdevd
         command: ["/bin/sh", "-c", "/home/pi/venv/bin/gunicorn --timeout 60 -b 0.0.0.0 nabweb.wsgi"]
         ports:
             - 8000:8000
-    # FIXME: nabmastodond will stop immediately because there's no nabd to connect to
-    # but at least it starts correctly, as a proof of concept
+    nab8balld:
+        build: ./nab
+        volumes:
+            - ../:/home/pi/pynab
+            - var-run-postgresql:/var/run/postgresql
+        depends_on:
+            - db
+            - migrate
+            - nabdevd
+        command: ["/bin/bash", "/usr/local/bin/run-service.sh", "nab8balld.nab8balld"]
+    nabairqualityd:
+        build: ./nab
+        volumes:
+            - ../:/home/pi/pynab
+            - var-run-postgresql:/var/run/postgresql
+        depends_on:
+            - db
+            - migrate
+            - nabdevd
+        command: ["/bin/bash", "/usr/local/bin/run-service.sh", "nabairqualityd.nabairqualityd"]
+    nabbookd:
+        build: ./nab
+        volumes:
+            - ../:/home/pi/pynab
+            - var-run-postgresql:/var/run/postgresql
+        depends_on:
+            - db
+            - migrate
+            - nabdevd
+        command: ["/bin/bash", "/usr/local/bin/run-service.sh", "nabbookd.nabbookd"]
+    nabclockd:
+        build: ./nab
+        volumes:
+            - ../:/home/pi/pynab
+            - var-run-postgresql:/var/run/postgresql
+        depends_on:
+            - db
+            - migrate
+            - nabdevd
+        command: ["/bin/bash", "/usr/local/bin/run-service.sh", "nabclockd.nabclockd"]
+    nabsurprised:
+        build: ./nab
+        volumes:
+            - ../:/home/pi/pynab
+            - var-run-postgresql:/var/run/postgresql
+        depends_on:
+            - db
+            - migrate
+            - nabdevd
+        command: ["/bin/bash", "/usr/local/bin/run-service.sh", "nabsurprised.nabsurprised"]
+    nabtaichid:
+        build: ./nab
+        volumes:
+            - ../:/home/pi/pynab
+            - var-run-postgresql:/var/run/postgresql
+        depends_on:
+            - db
+            - migrate
+            - nabdevd
+        command: ["/bin/bash", "/usr/local/bin/run-service.sh", "nabtaichid.nabtaichid"]
+    nabweatherd:
+        build: ./nab
+        volumes:
+            - ../:/home/pi/pynab
+            - var-run-postgresql:/var/run/postgresql
+        depends_on:
+            - db
+            - migrate
+            - nabdevd
+        command: ["/bin/bash", "/usr/local/bin/run-service.sh", "nabweatherd.nabweatherd"]
     nabmastodond:
         build: ./nab
         volumes:
@@ -39,6 +112,7 @@ services:
         depends_on:
             - db
             - migrate
+            - nabdevd
         command: ["/bin/bash", "/usr/local/bin/run-service.sh", "nabmastodond.nabmastodond"]
 
 volumes:

--- a/Docker/nab/Dockerfile
+++ b/Docker/nab/Dockerfile
@@ -15,6 +15,12 @@ RUN echo "Raspberry Pi reference 1970-01-01" > /etc/rpi-issue
 # Fake nabd systemd service file used to retrieve the working directory
 RUN echo "WorkingDirectory=/home/pi/pynab" > /lib/systemd/system/nabd.service
 
+# Fake systemd-time-wait-sync.service needed by nabclockd
+RUN mkdir -p /run/systemd/timesync/ && touch /run/systemd/timesync/synchronized
+
+# Naively fake systemctl, used to check if the SSH service is active
+RUN ln -s /bin/false /bin/systemctl
+
 # Make /var/log/ writable for service log files, /run for PID files
 RUN chmod a+w /var/log /run
 

--- a/Docker/nab/Dockerfile
+++ b/Docker/nab/Dockerfile
@@ -44,7 +44,6 @@ ENV PATH=${VIRTUAL_ENV}/bin:${PATH}
 COPY ./requirements_docker.txt /tmp
 RUN ${VIRTUAL_ENV}/bin/pip install -r /tmp/requirements_docker.txt
 
-ENV PYNAB_DEVELOPMENT=true
 ENV NABD_HOST=nabdevd
 
 EXPOSE 8000

--- a/Docker/nab/Dockerfile
+++ b/Docker/nab/Dockerfile
@@ -45,5 +45,6 @@ COPY ./requirements_docker.txt /tmp
 RUN ${VIRTUAL_ENV}/bin/pip install -r /tmp/requirements_docker.txt
 
 ENV PYNAB_DEVELOPMENT=true
+ENV NABD_HOST=nabdevd
 
 EXPOSE 8000

--- a/nabcommon/nabservice.py
+++ b/nabcommon/nabservice.py
@@ -93,7 +93,7 @@ class NabService(ABC):
 
     def _do_connect(self, retry_count):
         connection = asyncio.open_connection(
-            host="127.0.0.1", port=NabService.PORT_NUMBER
+            host=NabService.get_nabd_host(), port=NabService.PORT_NUMBER
         )
         try:
             (reader, writer) = self.loop.run_until_complete(connection)
@@ -146,6 +146,20 @@ class NabService(ABC):
             self.loop_cv.notify()
         """
         return None
+
+    @staticmethod
+    def get_nabd_host():
+        """
+        Returns the hostname to use to connect to nabd.
+        Typically that will be localhost / 127.0.0.1 however
+        when working with the Docker-based development environment
+        we connect to a dummy nabd daemon running in a separate
+        container under a specific hostname "nabdevd"
+        """
+        if os.getenv("PYNAB_DEVELOPMENT") is not None:
+            return "nabdevd"
+        else:
+            return "127.0.0.1"
 
     @classmethod
     def signal_daemon(cls):

--- a/nabcommon/nabservice.py
+++ b/nabcommon/nabservice.py
@@ -18,7 +18,8 @@ from nabcommon import nablogging, settings
 
 
 class NabService(ABC):
-    PORT_NUMBER = 10543
+    PORT_NUMBER = int(os.getenv("NABD_PORT_NUMBER", "10543"))
+    HOST = os.getenv("NABD_HOST", "127.0.0.1")
 
     def __init__(self):
         settings.configure(type(self).__name__.lower())
@@ -93,7 +94,7 @@ class NabService(ABC):
 
     def _do_connect(self, retry_count):
         connection = asyncio.open_connection(
-            host=NabService.get_nabd_host(), port=NabService.PORT_NUMBER
+            host=NabService.HOST, port=NabService.PORT_NUMBER
         )
         try:
             (reader, writer) = self.loop.run_until_complete(connection)
@@ -146,20 +147,6 @@ class NabService(ABC):
             self.loop_cv.notify()
         """
         return None
-
-    @staticmethod
-    def get_nabd_host():
-        """
-        Returns the hostname to use to connect to nabd.
-        Typically that will be localhost / 127.0.0.1 however
-        when working with the Docker-based development environment
-        we connect to a dummy nabd daemon running in a separate
-        container under a specific hostname "nabdevd"
-        """
-        if os.getenv("PYNAB_DEVELOPMENT") is not None:
-            return "nabdevd"
-        else:
-            return "127.0.0.1"
 
     @classmethod
     def signal_daemon(cls):

--- a/nabweb/urls.py
+++ b/nabweb/urls.py
@@ -15,8 +15,8 @@ Including another URLconf
 """
 
 from django.apps import apps
-from django.urls import include, path
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+from django.urls import include, path
 
 from .views import (
     NabWebHardwareTestView,

--- a/nabweb/urls.py
+++ b/nabweb/urls.py
@@ -17,6 +17,7 @@ import os
 
 from django.apps import apps
 from django.urls import include, path
+from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
 from .views import (
     NabWebHardwareTestView,
@@ -74,12 +75,9 @@ urlpatterns = [
     ),
 ]
 
-if os.getenv("PYNAB_DEVELOPMENT") is not None:
-    # Development environment does not use nginx, serve
-    # static files directly
-    from django.contrib.staticfiles.urls import staticfiles_urlpatterns
-
-    urlpatterns += staticfiles_urlpatterns()
+# Static files are served by nginx in the complete
+# installation so this is only useful when nginx is not used
+urlpatterns += staticfiles_urlpatterns()
 
 # Service URLs added automatically
 for config in apps.get_app_configs():

--- a/nabweb/urls.py
+++ b/nabweb/urls.py
@@ -13,7 +13,6 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-import os
 
 from django.apps import apps
 from django.urls import include, path

--- a/nabweb/views.py
+++ b/nabweb/views.py
@@ -22,9 +22,7 @@ from nabd.i18n import Config
 
 class NabdConnection:
     async def __aenter__(self):
-        conn = asyncio.open_connection(
-            NabService.get_nabd_host(), NabService.PORT_NUMBER
-        )
+        conn = asyncio.open_connection(NabService.HOST, NabService.PORT_NUMBER)
         self.reader, self.writer = await asyncio.wait_for(conn, 0.5)
         return self
 

--- a/nabweb/views.py
+++ b/nabweb/views.py
@@ -22,7 +22,9 @@ from nabd.i18n import Config
 
 class NabdConnection:
     async def __aenter__(self):
-        conn = asyncio.open_connection("127.0.0.1", NabService.PORT_NUMBER)
+        conn = asyncio.open_connection(
+            NabService.get_nabd_host(), NabService.PORT_NUMBER
+        )
         self.reader, self.writer = await asyncio.wait_for(conn, 0.5)
         return self
 


### PR DESCRIPTION
Provide a dummy nabd daemon that can be run on a regular computer
without the real hardware. This daemon runs in a separate Docker
container that all services can access.

The nabd connection host is changed from 127.0.0.1 to `nabdevd`
(container name = hostname) when running in development mode, based on an
environment variable. This allows to run all services, each in their own
container.

The dummy daemon is named `nabdevd` and lives in a separate repository:
https://gitlab.com/nguillaumin/nabdevd . It may make sense to move it
inside the nabaztag2018 GitHub account at some point.

The dummy daemon is limited for now, but implements enough of the
protocol for the services to run. The plan is to simulate as many
features as possible of the real nabd, possibly with some control
interface to simulate button presses or ears manipulation.