### PR TITLE
Remove 'boot chime' feature.

### DIFF
--- a/nabd/nabd.py
+++ b/nabd/nabd.py
@@ -68,7 +68,6 @@ class Nabd:
         self._ears_moved_task = None
         self.playing_cancelable = False
         self.playing_request_id = None
-        self.boot = True
         Nabd.leds_boot(self.nabio, 2)
         if self.nabio.has_sound_input():
             from . import i18n
@@ -87,7 +86,6 @@ class Nabd:
         """
         Reload configuration.
         """
-        self.boot = True
         if self.nabio.has_sound_input():
             from . import i18n
             from .asr import ASR
@@ -112,15 +110,6 @@ class Nabd:
                 Nabd.leds_boot(self.nabio, 4)
             self.nabio.set_leds(None, None, None, None, None)
         self.nabio.pulse(Led.BOTTOM, (255, 0, 255))
-        await self.boot_playsound()
-
-    async def boot_playsound(self):
-        """
-        Play sound indicating end of boot.
-        """
-        if self.boot:
-            await self.nabio.play_sequence([{"audio": ["boot/*.mp3"]}])
-            self.boot = False
 
     async def _do_transition_to_idle(self):
         """
@@ -131,11 +120,9 @@ class Nabd:
         left, right = self.ears["left"], self.ears["right"]
         await self.nabio.move_ears_with_leds((255, 0, 255), left, right)
         self.nabio.pulse(Led.BOTTOM, (255, 0, 255))
-        await self.boot_playsound()
 
     async def sleep_setup(self):
         self.nabio.set_leds(None, None, None, None, None)
-        await self.boot_playsound()
         await self.nabio.move_ears(
             Nabd.SLEEP_EAR_POSITION, Nabd.SLEEP_EAR_POSITION
         )

--- a/nabd/sounds/boot/Chime01.mp3
+++ b/nabd/sounds/boot/Chime01.mp3
@@ -1,1 +1,0 @@
-../../../nabsurprised/sounds/nabsurprised/respirations/Respiration01.mp3

--- a/nabd/sounds/boot/Chime02.mp3
+++ b/nabd/sounds/boot/Chime02.mp3
@@ -1,1 +1,0 @@
-../../../nabsurprised/sounds/nabsurprised/respirations/Respiration02.mp3

--- a/nabd/sounds/boot/Chime03.mp3
+++ b/nabd/sounds/boot/Chime03.mp3
@@ -1,1 +1,0 @@
-../../../nabsurprised/sounds/nabsurprised/respirations/Respiration03.mp3

--- a/nabd/sounds/boot/Chime04.mp3
+++ b/nabd/sounds/boot/Chime04.mp3
@@ -1,1 +1,0 @@
-../../../nabsurprised/sounds/nabsurprised/respirations/Respiration04.mp3

--- a/nabd/sounds/boot/Chime05.mp3
+++ b/nabd/sounds/boot/Chime05.mp3
@@ -1,1 +1,0 @@
-../../../nabsurprised/sounds/nabsurprised/respirations/Respiration05.mp3

--- a/nabd/sounds/boot/Chime06.mp3
+++ b/nabd/sounds/boot/Chime06.mp3
@@ -1,1 +1,0 @@
-../../../nabsurprised/sounds/nabsurprised/respirations/Respiration06.mp3

--- a/nabd/sounds/boot/Chime07.mp3
+++ b/nabd/sounds/boot/Chime07.mp3
@@ -1,1 +1,0 @@
-../../../nabsurprised/sounds/nabsurprised/respirations/Respiration07.mp3

--- a/nabd/sounds/boot/Chime08.mp3
+++ b/nabd/sounds/boot/Chime08.mp3
@@ -1,1 +1,0 @@
-../../../nabsurprised/sounds/nabsurprised/respirations/Respiration08.mp3

--- a/nabd/sounds/boot/Chime09.mp3
+++ b/nabd/sounds/boot/Chime09.mp3
@@ -1,1 +1,0 @@
-../../../nabsurprised/sounds/nabsurprised/respirations/Respiration09.mp3

--- a/nabd/sounds/boot/Chime10.mp3
+++ b/nabd/sounds/boot/Chime10.mp3
@@ -1,1 +1,0 @@
-../../../nabsurprised/sounds/nabsurprised/respirations/Respiration10.mp3

--- a/nabd/sounds/boot/Chime11.mp3
+++ b/nabd/sounds/boot/Chime11.mp3
@@ -1,1 +1,0 @@
-../../../nabsurprised/sounds/nabsurprised/respirations/Respiration11.mp3

--- a/nabd/sounds/boot/Chime12.mp3
+++ b/nabd/sounds/boot/Chime12.mp3
@@ -1,1 +1,0 @@
-../../../nabsurprised/sounds/nabsurprised/respirations/Respiration12.mp3

--- a/nabd/sounds/boot/Chime13.mp3
+++ b/nabd/sounds/boot/Chime13.mp3
@@ -1,1 +1,0 @@
-../../../nabmastodond/sounds/nabmastodond/respirations/Respiration13.mp3

--- a/nabd/sounds/boot/Chime14.mp3
+++ b/nabd/sounds/boot/Chime14.mp3
@@ -1,1 +1,0 @@
-../../../nabmastodond/sounds/nabmastodond/respirations/Respiration14.mp3


### PR DESCRIPTION
Resolves #228.
This removes the 'boot chime feature' altogether, pending a new implementation that would keep the rabbit silent while asleep.