### PR TITLE
Air quality: cleanup widget location display

### DIFF
--- a/nabairqualityd/aqicn.py
+++ b/nabairqualityd/aqicn.py
@@ -8,6 +8,9 @@ import logging
 
 import requests
 
+AQICN_FEED = "http://api.waqi.info/feed/"
+AQICN_TOKEN = "4cf7f445134f3fb69a4c3f0e5001e507a6cc386f"
+
 
 class aqicnError(Exception):
     """Raise when errors occur while fetching or parsing data"""
@@ -35,15 +38,17 @@ class aqicnClient:
         if lat and lon:
             # Use geolocalized API
             return (
-                "https://api.waqi.info/feed/geo:" + lat + ";" + lon + "/"
-                "?token=4cf7f445134f3fb69a4c3f0e5001e507a6cc386f"
+                AQICN_FEED
+                + "geo:"
+                + lat
+                + ";"
+                + lon
+                + "/?token="
+                + AQICN_TOKEN
             )
         else:
             # fallback to IP-based API
-            return (
-                "http://api.waqi.info/feed/here/"
-                "?token=4cf7f445134f3fb69a4c3f0e5001e507a6cc386f"
-            )
+            return AQICN_FEED + "here/?token=" + AQICN_TOKEN
 
     def _fetch_airquality_data(self):
         try:

--- a/nabairqualityd/aqicn.py
+++ b/nabairqualityd/aqicn.py
@@ -37,18 +37,10 @@ class aqicnClient:
         """Select AQICN URL to use"""
         if lat and lon:
             # Use geolocalized API
-            return (
-                AQICN_FEED
-                + "geo:"
-                + lat
-                + ";"
-                + lon
-                + "/?token="
-                + AQICN_TOKEN
-            )
+            return f"{AQICN_FEED}geo:{lat};{lon}/?token={AQICN_TOKEN}"
         else:
             # fallback to IP-based API
-            return AQICN_FEED + "here/?token=" + AQICN_TOKEN
+            return f"{AQICN_FEED}here/?token={AQICN_TOKEN}"
 
     def _fetch_airquality_data(self):
         try:

--- a/nabairqualityd/locale/fr_FR/LC_MESSAGES/django.po
+++ b/nabairqualityd/locale/fr_FR/LC_MESSAGES/django.po
@@ -74,49 +74,57 @@ msgid " by saying such things as <q>What is the air quality today ?</q>."
 msgstr " en disant par exemple <q>Qualité de l'air</q>."
 
 #: templates/nabairqualityd/settings.html:13
+msgid "Location"
+msgstr "Localisation"
+
+#: templates/nabairqualityd/settings.html:15
+msgid "Station location"
+msgstr "Locatisation de la station"
+
+#: templates/nabairqualityd/settings.html:20
 msgid "Index"
 msgstr "Indice"
 
-#: templates/nabairqualityd/settings.html:16
+#: templates/nabairqualityd/settings.html:23
 msgid "AQI"
 msgstr "AQI"
 
-#: templates/nabairqualityd/settings.html:17
+#: templates/nabairqualityd/settings.html:24
 msgid "PM 2.5"
 msgstr "PM 2.5"
 
-#: templates/nabairqualityd/settings.html:23
+#: templates/nabairqualityd/settings.html:30
 msgid "Visual animation"
 msgstr "Information visuelle"
 
-#: templates/nabairqualityd/settings.html:26
+#: templates/nabairqualityd/settings.html:33
 msgid "Always-on"
 msgstr "Toujours afficher"
 
-#: templates/nabairqualityd/settings.html:27
+#: templates/nabairqualityd/settings.html:34
 msgid "Alert only"
 msgstr "Afficher les alertes uniquement"
 
-#: templates/nabairqualityd/settings.html:28
+#: templates/nabairqualityd/settings.html:35
 msgid "No visual animation"
 msgstr "Aucune information visuelle"
 
-#: templates/nabairqualityd/settings.html:34
+#: templates/nabairqualityd/settings.html:41
 msgid "Forecast"
 msgstr "Prévision"
 
-#: templates/nabairqualityd/settings.html:36
+#: templates/nabairqualityd/settings.html:43
 msgid "Today"
 msgstr "Aujourd'hui"
 
-#: templates/nabairqualityd/settings.html:43
+#: templates/nabairqualityd/settings.html:50
 msgid "Save"
 msgstr "Enregistrer"
 
-#: templates/nabairqualityd/settings.html:44
+#: templates/nabairqualityd/settings.html:51
 msgid "Reset"
 msgstr "Annuler"
 
-#: templates/nabairqualityd/settings.html:74
+#: templates/nabairqualityd/settings.html:81
 msgid "Unknown server error"
 msgstr "Erreur inconnue du serveur"

--- a/nabairqualityd/nabairqualityd.py
+++ b/nabairqualityd/nabairqualityd.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import logging
 import sys
 
 from asgiref.sync import sync_to_async
@@ -102,9 +103,15 @@ class NabAirqualityd(NabInfoCachedService):
         from . import models
 
         config = await models.Config.load_async()
-        new_city = client.get_city()
-        if new_city != config.localisation:
-            config.localisation = new_city
+        city = client.get_city()
+        if city != config.localisation:
+            logging.debug(
+                "Air quality city changed from: "
+                + str(config.localisation)
+                + " to: "
+                + str(city)
+            )
+            config.localisation = city
             await config.save_async()
 
         return {

--- a/nabairqualityd/templates/nabairqualityd/settings.html
+++ b/nabairqualityd/templates/nabairqualityd/settings.html
@@ -3,11 +3,18 @@
   <form action="/nabairqualityd/settings">
     {% csrf_token %}
     <div class="card-header">
-      <h5 class="card-title">{% trans "Air quality" %} - {{ config.localisation }}</h5>
+      <h5 class="card-title">{% trans "Air quality" %}</h5>
     </div>
     <div class="card-body">
         <p>{% trans "The " %}<a class="help-link" href='/help/airquality' target='_blank' title='{% trans "The air quality visual animations" %}'>{% trans "visual animation" %}</a>{% trans " displays air quality information based on the location selected for Weather. You can select the type of information you want : Aggregate index (AQI) or just particulate matter (PM 2.5)." %}</p>
       <p>{% trans "You can also " %}<a class="help-link" href='/help/#asr' target='_blank' title='{% trans "Speech recognition" %}'>{% trans "ask your rabbit" %}</a>{% blocktrans %} by saying such things as <q>What is the air quality today ?</q>.{% endblocktrans %}</p>
+
+      <div class="form-group row">
+        <label for="airqualityLocation" class="col-6 col-form-label">{% trans "Location" %}</label>
+        <div class="col-6">
+          <input id="airqualityLocation" name="station_location" type="text" class="form-control" placeholder="{% trans "Station location" %}" value="{{ config.localisation }}" disabled/>
+        </div>
+      </div>
 
       <div class="form-group row">
         <label for="airqualityIndexSel" class="col-6 col-form-label">{% trans "Index" %}</label>


### PR DESCRIPTION
Change  location display in Air quality widget, at the expense of a little screen estate, to be similar to Weather widget.
(Note: this PR does **not** correct issue #245.)