### PR TITLE
👷 Fix typo in Pull Request auto labelling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -55,4 +55,4 @@
   - nabweb/**
 
 'Translations':
-  - **/*.po
+  - '**/*.po'


### PR DESCRIPTION
This time, YAML is [valid](https://yamlvalidator.com/).

See [mehdichaouch/pynab/pulls](https://github.com/mehdichaouch/pynab/pulls)