### PR TITLE
Revamp home page and add help page

### DIFF
--- a/nabclockd/locale/fr_FR/LC_MESSAGES/django.po
+++ b/nabclockd/locale/fr_FR/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-28 08:57+0200\n"
+"POT-Creation-Date: 2021-05-28 10:44+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,7 +16,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
 
 #: templates/nabclockd/settings.html:6
 msgid "Clock"
@@ -26,64 +25,58 @@ msgstr "Horloge"
 msgid "Chime hours"
 msgstr "Sonner les heures"
 
-#: templates/nabclockd/settings.html:18
+#: templates/nabclockd/settings.html:17
 msgid "Custom hours for each day of the week"
 msgstr "Horaires personnalisés pour chaque jour de la semaine"
 
-#: templates/nabclockd/settings.html:27
-msgid "Wake-up time"
+#: templates/nabclockd/settings.html:25
+msgid "Wake up time"
 msgstr "Heure de réveil"
 
-#: templates/nabclockd/settings.html:38
+#: templates/nabclockd/settings.html:36
 msgid "Sleep time"
 msgstr "Heure du coucher"
 
-#: templates/nabclockd/settings.html:52
-msgid "Monday - Wake-up / Sleep"
+#: templates/nabclockd/settings.html:49
+msgid "Monday - Wake up / Sleep"
 msgstr "Lundi - Réveil / Coucher"
 
-#: templates/nabclockd/settings.html:72
-msgid "Tuesday - Wake-up / Sleep"
+#: templates/nabclockd/settings.html:68
+msgid "Tuesday - Wake up / Sleep"
 msgstr "Mardi - Réveil / Coucher"
 
-#: templates/nabclockd/settings.html:92
-msgid "Wednesday - Wake-up / Sleep"
+#: templates/nabclockd/settings.html:87
+msgid "Wednesday - Wake up / Sleep"
 msgstr "Mercredi - Réveil / Coucher"
 
-#: templates/nabclockd/settings.html:112
-msgid "Thursday - Wake-up / Sleep"
+#: templates/nabclockd/settings.html:106
+msgid "Thursday - Wake up / Sleep"
 msgstr "Jeudi - Réveil / Coucher"
 
-#: templates/nabclockd/settings.html:132
-msgid "Friday - Wake-up / Sleep"
+#: templates/nabclockd/settings.html:125
+msgid "Friday - Wake up / Sleep"
 msgstr "Vendredi - Réveil / Coucher"
 
-#: templates/nabclockd/settings.html:152
-msgid "Saturday - Wake-up / Sleep"
+#: templates/nabclockd/settings.html:144
+msgid "Saturday - Wake up / Sleep"
 msgstr "Samedi - Réveil / Coucher"
 
-#: templates/nabclockd/settings.html:172
-msgid "Sunday - Wake-up / Sleep"
+#: templates/nabclockd/settings.html:163
+msgid "Sunday - Wake up / Sleep"
 msgstr "Dimanche - Réveil / Coucher"
 
-#: templates/nabclockd/settings.html:61 templates/nabclockd/settings.html:81
-#: templates/nabclockd/settings.html:101 templates/nabclockd/settings.html:121
-#: templates/nabclockd/settings.html:141 templates/nabclockd/settings.html:161
-msgid "Sleep"
-msgstr "Coucher"
-
-#: templates/nabclockd/settings.html:194
+#: templates/nabclockd/settings.html:183
 msgid "Time zone"
 msgstr "Fuseau horaire"
 
-#: templates/nabclockd/settings.html:204
+#: templates/nabclockd/settings.html:193
 msgid "Play wake up and sleep sound"
-msgstr "Jouer un son au reveil et coucher"
+msgstr "Jouer un son au réveil et au coucher"
 
-#: templates/nabclockd/settings.html:214
+#: templates/nabclockd/settings.html:203
 msgid "Save"
-msgstr ""
+msgstr "Enregistrer"
 
-#: templates/nabclockd/settings.html:215
+#: templates/nabclockd/settings.html:204
 msgid "Reset"
-msgstr ""
+msgstr "Annuler"

--- a/nabclockd/templates/nabclockd/settings.html
+++ b/nabclockd/templates/nabclockd/settings.html
@@ -22,7 +22,7 @@
       </div>      
       <div id="commonWakeUpTimes" style="{% if config.settings_per_day %}display:none{% endif %}">      
         <div class="form-group row">
-          <label for="wakeupTime" class="col-6 col-form-label">{% trans "Wake-up time" %}</label>
+          <label for="wakeupTime" class="col-6 col-form-label">{% trans "Wake up time" %}</label>
           <div class="col-6">
             <div class="input-group clockpicker" data-autoclose="true">
               <input id="wakeupTime" name="wakeup_time" type="text" class="form-control" value="{% if config.wakeup_hour < 10 %}0{% endif %}{{ config.wakeup_hour }}:{% if config.wakeup_min < 10 %}0{% endif %}{{ config.wakeup_min }}">
@@ -46,7 +46,7 @@
       </div>
       <div id="distinctWakeUpTimes" style="{% if not config.settings_per_day %}display:none{% endif %}">
         <div class="form-group row">
-          <label for="wakeupTimeMonday" class="col-4 col-form-label">{% trans "Monday - Wake-up / Sleep" %}</label>
+          <label for="wakeupTimeMonday" class="col-4 col-form-label">{% trans "Monday - Wake up / Sleep" %}</label>
           <div class="col-4">
             <div class="input-group clockpicker" data-autoclose="true">
               <input id="wakeupTimeMonday" name="wakeup_time_monday" type="text" class="form-control" value="{% if config.wakeup_hour_monday < 10 %}0{% endif %}{{ config.wakeup_hour_monday }}:{% if config.wakeup_min_monday < 10 %}0{% endif %}{{ config.wakeup_min_monday }}">
@@ -65,7 +65,7 @@
           </div>          
         </div>
         <div class="form-group row">
-          <label for="wakeupTimeTuesday" class="col-4 col-form-label">{% trans "Tuesday - Wake-up / Sleep" %}</label>
+          <label for="wakeupTimeTuesday" class="col-4 col-form-label">{% trans "Tuesday - Wake up / Sleep" %}</label>
           <div class="col-4">
             <div class="input-group clockpicker" data-autoclose="true">
               <input id="wakeupTimeTuesday" name="wakeup_time_tuesday" type="text" class="form-control" value="{% if config.wakeup_hour_tuesday < 10 %}0{% endif %}{{ config.wakeup_hour_tuesday }}:{% if config.wakeup_min_tuesday < 10 %}0{% endif %}{{ config.wakeup_min_tuesday }}">
@@ -84,7 +84,7 @@
           </div>          
         </div>
         <div class="form-group row">
-          <label for="wakeupTimeWednesday" class="col-4 col-form-label">{% trans "Wednesday - Wake-up / Sleep" %}</label>
+          <label for="wakeupTimeWednesday" class="col-4 col-form-label">{% trans "Wednesday - Wake up / Sleep" %}</label>
           <div class="col-4">
             <div class="input-group clockpicker" data-autoclose="true">
               <input id="wakeupTimeWednesday" name="wakeup_time_wednesday" type="text" class="form-control" value="{% if config.wakeup_hour_wednesday < 10 %}0{% endif %}{{ config.wakeup_hour_wednesday }}:{% if config.wakeup_min_wednesday < 10 %}0{% endif %}{{ config.wakeup_min_wednesday }}">
@@ -103,7 +103,7 @@
           </div>          
         </div>
         <div class="form-group row">
-          <label for="wakeupTimeThursday" class="col-4 col-form-label">{% trans "Thursday - Wake-up / Sleep" %}</label>
+          <label for="wakeupTimeThursday" class="col-4 col-form-label">{% trans "Thursday - Wake up / Sleep" %}</label>
           <div class="col-4">
             <div class="input-group clockpicker" data-autoclose="true">
               <input id="wakeupTimeThursday" name="wakeup_time_thursday" type="text" class="form-control" value="{% if config.wakeup_hour_thursday < 10 %}0{% endif %}{{ config.wakeup_hour_thursday }}:{% if config.wakeup_min_thursday < 10 %}0{% endif %}{{ config.wakeup_min_thursday }}">
@@ -122,7 +122,7 @@
           </div>          
         </div>
         <div class="form-group row">
-          <label for="wakeupTimeFriday" class="col-4 col-form-label">{% trans "Friday - Wake-up / Sleep" %}</label>
+          <label for="wakeupTimeFriday" class="col-4 col-form-label">{% trans "Friday - Wake up / Sleep" %}</label>
           <div class="col-4">
             <div class="input-group clockpicker" data-autoclose="true">
               <input id="wakeupTimeFriday" name="wakeup_time_friday" type="text" class="form-control" value="{% if config.wakeup_hour_friday < 10 %}0{% endif %}{{ config.wakeup_hour_friday }}:{% if config.wakeup_min_friday < 10 %}0{% endif %}{{ config.wakeup_min_friday }}">
@@ -141,7 +141,7 @@
           </div>          
         </div>
         <div class="form-group row">
-          <label for="wakeupTimeSaturday" class="col-4 col-form-label">{% trans "Saturday - Wake-up / Sleep" %}</label>
+          <label for="wakeupTimeSaturday" class="col-4 col-form-label">{% trans "Saturday - Wake up / Sleep" %}</label>
           <div class="col-4">
             <div class="input-group clockpicker" data-autoclose="true">
               <input id="wakeupTimeSaturday" name="wakeup_time_saturday" type="text" class="form-control" value="{% if config.wakeup_hour_saturday < 10 %}0{% endif %}{{ config.wakeup_hour_saturday }}:{% if config.wakeup_min_saturday < 10 %}0{% endif %}{{ config.wakeup_min_saturday }}">
@@ -160,7 +160,7 @@
           </div>          
         </div>
         <div class="form-group row">
-          <label for="wakeupTimeSunday" class="col-4 col-form-label">{% trans "Sunday - Wake-up / Sleep" %}</label>
+          <label for="wakeupTimeSunday" class="col-4 col-form-label">{% trans "Sunday - Wake up / Sleep" %}</label>
           <div class="col-4">
             <div class="input-group clockpicker" data-autoclose="true">
               <input id="wakeupTimeSunday" name="wakeup_time_sunday" type="text" class="form-control" value="{% if config.wakeup_hour_sunday < 10 %}0{% endif %}{{ config.wakeup_hour_sunday }}:{% if config.wakeup_min_sunday < 10 %}0{% endif %}{{ config.wakeup_min_sunday }}">

--- a/nabweb/locale/fr_FR/LC_MESSAGES/django.po
+++ b/nabweb/locale/fr_FR/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-25 23:42+0200\n"
+"POT-Creation-Date: 2021-05-28 18:45+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -54,14 +54,16 @@ msgstr "Portugais brésilien"
 msgid "Nabaztag configuration"
 msgstr "Configuration du Nabaztag"
 
-#: templates/nabweb/_base.html:32 templates/nabweb/index.html:3
+#: templates/nabweb/_base.html:32 templates/nabweb/_help.html:44
+#: templates/nabweb/help.html:3 templates/nabweb/index.html:3
 #: templates/nabweb/upgrade/index.html:3
 msgid "Home"
 msgstr "Accueil"
 
 #: templates/nabweb/_base.html:32 templates/nabweb/_base.html:33
 #: templates/nabweb/_base.html:34 templates/nabweb/_base.html:35
-#: templates/nabweb/_base.html:36
+#: templates/nabweb/_base.html:36 templates/nabweb/_base.html:37
+#: templates/nabweb/_help.html:44
 msgid "(current)"
 msgstr "(actif)"
 
@@ -83,9 +85,9 @@ msgstr "Information système"
 msgid "Upgrade"
 msgstr "Mise à jour"
 
-#: templates/nabweb/_base.html:37 templates/nabweb/_help.html:43
-msgid "Help!"
-msgstr "Aide !"
+#: templates/nabweb/_base.html:37
+msgid "Help"
+msgstr "Aide"
 
 #: templates/nabweb/_base.html:51
 msgid "Upgrading"
@@ -99,72 +101,220 @@ msgstr "Veuillez patienter pendant la mise à jour de pynab"
 msgid "Unknown server error"
 msgstr "Erreur serveur inconnue"
 
-#: templates/nabweb/_help.html:13 templates/nabweb/_help.html:37
+#: templates/nabweb/_help.html:13 templates/nabweb/_help.html:38
+#: templates/nabweb/help.html:7
 msgid "Nabaztag help"
 msgstr "Aide du Nabaztag"
 
+#: templates/nabweb/help.html:9
+msgid "On your rabbit"
+msgstr "Sur votre lapin"
+
+#: templates/nabweb/help.html:10 templates/nabweb/help.html:11
+msgid "<b>The "
+msgstr "<b>Les "
+
+#: templates/nabweb/help.html:10
+msgid "The weather forecast visual animations"
+msgstr "Les animations visuelles Météo"
+
+#: templates/nabweb/help.html:10
+msgid "weather forecast visual animations"
+msgstr "animations visuelles Météo"
+
+#: templates/nabweb/help.html:11
+msgid "The air quality visual animations"
+msgstr "Les animations visuelles Qualité de l'air"
+
+#: templates/nabweb/help.html:11
+msgid "air quality visual animations"
+msgstr "animations visuelles Qualité de l'air"
+
+#: templates/nabweb/help.html:12
+msgid "Talking to the rabbit (speech recognition)"
+msgstr "Commnent parler au lapin (reconnaissance vocale)"
+
+#: templates/nabweb/help.html:12
+msgid ""
+"You need to push and hold the button on the rabbit's head long enough to "
+"hear a 'beep', then wait a couple of seconds and speak. When you are done "
+"just release the button."
+msgstr ""
+"Il vous faut maintenir le bouton sur la tête du lapin appuyé assez longtemps "
+"pour entendre le 'bip', attendre quelques secondes puis parler. Relachez "
+"quand vous avez terminé."
+
+#: templates/nabweb/help.html:12
+msgid ""
+"The speech processing is done locally and the answer should come shortly!"
+msgstr ""
+"La reconnaissance vocale est effectuée localement et la réponse devrait être "
+"rapide !"
+
+#: templates/nabweb/help.html:13
+msgid "Reboot or shutdown the rabbit"
+msgstr "Redémarrer ou arrêter le lapin"
+
+#: templates/nabweb/help.html:13
+msgid ""
+"You can do this cleanly by using the <kbd class=\"btn-warning\">Reboot</kbd> "
+"or <kbd class=\"btn-danger\">Shutdown</kbd> buttons on the <a  "
+"target='_parent' href='/system-info/'>System information</a> tab of the "
+"configuration page."
+msgstr ""
+"You pouvez le faire proprement en utilisant les boutons <kbd class=\"btn-"
+"warning\">Redémarrer</kbd> ou <kbd class=\"btn-danger\">Arrêter</kbd> sur "
+"l'onglet <a  target='_parent' href='/system-info/'>Information système</a> "
+"de la page de configuration."
+
+#: templates/nabweb/help.html:13
+msgid ""
+"As a last resort, you can also shutdown the rabbit by pushing its head "
+"button quickly three times in a row."
+msgstr ""
+"En dernier ressort, vous pouvez aussi arrêter le lapin en appuyant le bouton "
+"sur sa tête rapidement trois fois à la suite."
+
+#: templates/nabweb/help.html:15
+msgid "On the Internet"
+msgstr "Sur l'Internet"
+
+#: templates/nabweb/help.html:16
+msgid ""
+"<a target='_blank' href='https://tinyletter.com/nabaztag' rel='noopener "
+"noreferrer'>Nabaztag is back!</a>"
+msgstr ""
+"<a target='_blank' href='https://tinyletter.com/nabaztag' rel='noopener "
+"noreferrer'>Nabaztag revient !</a>"
+
+#: templates/nabweb/help.html:16
+msgid "Subscribe to the newsletter."
+msgstr "Abonnez vous à la lettre d'information."
+
+#: templates/nabweb/help.html:17
+msgid ""
+"The <a target='_blank' href='https://www.tagtagtag.fr/forum/' rel='noopener "
+"noreferrer'>Tag:Tag:Tag user forum</a>"
+msgstr ""
+"Le <a target='_blank' href='https://www.tagtagtag.fr/forum/' rel='noopener "
+"noreferrer'>forum d'utilisateurs Tag:Tag:Tag</a>"
+
+#: templates/nabweb/help.html:17
+msgid "Share your problems and solutions with other rabbit breeders."
+msgstr ""
+"Partagez vos problèmes et vos solutions avec d'autres éleveurs de lapins."
+
+#: templates/nabweb/help.html:18
+msgid ""
+"The <a target='_blank' href='https://github.com/nabaztag2018/pynab/#readme' "
+"rel='noopener noreferrer'>GitHub repository</a>"
+msgstr ""
+"Le <a target='_blank' href='https://github.com/nabaztag2018/pynab/#readme' "
+"rel='noopener noreferrer'>référentiel GitHub</a>"
+
+#: templates/nabweb/help.html:18
+msgid "Report bugs or contribute to the project with other developers."
+msgstr ""
+"Signalez des bogues ou contribuez au projet avec d'autres développeurs."
+
+#: templates/nabweb/help.html:19
+msgid ""
+"<a target='_blank' href='https://twitter.com/nabaztagtagtag' rel='noopener "
+"noreferrer'>Nabaztag on Twitter</a>"
+msgstr ""
+"<a target='_blank' href='https://twitter.com/nabaztagtagtag' rel='noopener "
+"noreferrer'>Nabaztag sur Twitter</a>"
+
+#: templates/nabweb/help.html:20
+msgid ""
+"The <a target='_blank' href='https://www.instructables.com/member/"
+"tagtagtag/' rel='noopener noreferrer'>TagTagTag assembly instructions</a>"
+msgstr ""
+"Les <a target='_blank' href='https://www.instructables.com/member/"
+"tagtagtag/' rel='noopener noreferrer'>instructions de montage TagTagTag</a>"
+
+#: templates/nabweb/help.html:20
+msgid ""
+"The open heart operation to transplant the card into your rabbit. At this "
+"stage you probably do not need this anymore..."
+msgstr ""
+"L'opération à cœur ouvert pour transplanter la carte dans votre lapin. A ce "
+"stade, vous n'en avez probablement plus besoin ..."
+
+#: templates/nabweb/help.html:21
+msgid ""
+"<a target='_blank' href='https://www.ulule.com/le-retour-du-retour-du-"
+"nabaztag/' rel='noopener noreferrer'>Nabaztag is BackBack</a>"
+msgstr ""
+"Le <a target='_blank' href='https://fr.ulule.com/le-retour-du-retour-du-"
+"nabaztag/' rel='noopener noreferrer'>retour du retour du Nabaztag</a>"
+
+#: templates/nabweb/help.html:21
+msgid "Some project history..."
+msgstr "Un peu d'histoire ..."
+
 #: templates/nabweb/index.html:8
-msgid "You're currently deeply connected with your inner rabbit."
+msgid "You are currently connected to your rabbit."
 msgstr "Vous êtes actuellement en connexion avec votre lapin."
 
 #: templates/nabweb/index.html:10
-msgid ""
-"First, make sure the language is properly configured below. Maybe create an "
-"account to connect your Nabaztag to <a href='https://mstdn.fr/auth/"
-"sign_up'>Mastodon</a> where it will join fellow rabbits <small>(for now, "
-"this is only used by ear communion service)</small>."
+msgid "First, make sure the language is properly configured below."
 msgstr ""
-"Le mieux est de commencer par sélectionner la langue dans laquelle votre "
-"Nabaztag va s'exprimer. Ensuite, si vous connaissez d'autres lapins, vous "
-"pouvez aussi <a href='https://mstdn.fr/auth/sign_up'>créer un profil "
-"Mastodon</a> pour qu'il puisse dialoguer avec d'autres lapins (Mastodon est "
-"une sorte de Twitter open-source)."
+"Sélectionnez d'abord ci-dessous la langue dans laquelle votre Nabaztag va "
+"s'exprimer."
+
+#: templates/nabweb/index.html:10
+msgid ""
+"Then maybe create an account to connect your Nabaztag to <a target='_blank' "
+"href='https://joinmastodon.org' rel='noopener noreferrer'>Mastodon</a> where "
+"it may join fellow rabbits <small>(for now, this is only used by ear "
+"communion service)</small>."
+msgstr ""
+"Ensuite, si vous connaissez d'autres lapins, vous pouvez aussi créer un "
+"profil <a target='_blank' href='https://joinmastodon.org' rel='noopener "
+"noreferrer'>Mastodon</a> pour qu'il puisse dialoguer avec eux <small>(pour "
+"l'instant, ceci est utilisé uniquement pour la communion d'oreilles)</small>."
 
 #: templates/nabweb/index.html:11
 msgid ""
-"Eventually, explore top navigation bar to configure <a href='/"
-"services/'>Nabaztag services</a>, <a href='/upgrade/'>upgrade software</a> "
-"or even visit the <a target='_blank' href='https://github.com/nabaztag2018/"
-"pynab' rel='noopener noreferrer'>GitHub repository</a> to start hacking, "
-"adding features or simply report bugs."
+"Eventually, explore the top navigation bar to configure <a href='/"
+"services/'>Nabaztag services</a> or <a href='/rfid/'>RFID tags</a>, <a "
+"href='/upgrade/'>upgrade software</a>, <a target='_blank' href='/help/'>get "
+"help</a> or even visit the <a target='_blank' href='https://github.com/"
+"nabaztag2018/pynab' rel='noopener noreferrer'>GitHub repository</a> to start "
+"hacking, adding features or simply report bugs."
 msgstr ""
-"Pour configurer les services, allez dans l'onglet <a href='/"
-"services/'>Services</a>, ou <a href='/upgrade/'>Mise à jour</a> pour mettre "
-"à jour le logiciel. Vous pouvez aussi visiter le <a target='_blank' "
-"href='https://github.com/nabaztag2018/pynab' rel='noopener "
-"noreferrer'>GitHub repository</a> pour contribuer ou simplement nous "
-"reporter des bugs !"
+"Utilisez la barre de navigation pour configurer les <a href='/"
+"services/'>services du Nabaztag</a> ou des <a href='/rfid/'>tags RFID</a>, "
+"<a href='/upgrade/'>mettre à jour</a> le logiciel, ou <a target='_blank' "
+"href='/help/'>obtenir de l'aide</a>. Vous pouvez aussi visiter le <a "
+"target='_blank' href='https://github.com/nabaztag2018/pynab' rel='noopener "
+"noreferrer'>référentiel GitHub</a> pour contribuer ou simplement signaler "
+"des bogues."
 
 #: templates/nabweb/index.html:13
 msgid ""
-"You can trigger some services with your voice. The processing is done "
-"locally and you need to push the button long enough to hear a 'bip' (keep "
-"the button pushed), then wait a couple of seconds (We'll have a look at this "
-"later!) then speak and when you're done just release the button. Your "
-"service should be played shortly!"
+"You can also trigger some services with your voice by pushing and holding "
+"the button on the rabbit's head."
 msgstr ""
-"Vous pouvez aussi déclencher certains services en demandant à Nabaztag. La "
-"reconnaissance vocale est effectuée localement et il vous faut appuyer sur "
-"le bouton (en le maintenant appuyé), attendre le 'bip', attendre encore "
-"quelques secondes (oui c'est un bug) puis parler. Relacher quand vous n'avez "
-"plus rien à dire et attendez que Nabaztag vous réponde."
+"Vous pouvez aussi déclencher certains services à la voix en maintenant "
+"appuyé le bouton sur la tête du lapin."
 
-#: templates/nabweb/index.html:14
+#: templates/nabweb/index.html:15
 msgid ""
-"And don't forget to try <a href='/' onclick='javascript:event.target."
-"port=8080' target='_blank' rel='noopener noreferrer'>Nabblocky</a> and learn "
-"how to code with Nabaztag. It's fantastic."
+"And do not forget to try <a href='/' onclick='javascript:event.target."
+"port=8080' target='_blank' rel='noopener noreferrer'>NabBlockly</a> and "
+"learn how to code with Nabaztag. It's fantastic."
 msgstr ""
 "Et n'oubliez pas d'essayer <a href='/' onclick='javascript:event.target."
-"port=8080' target='_blank' rel='noopener noreferrer'>Nabblocky</a>. Pour "
-"tous ceux qui veulent apprendre à développer avec Nabaztag. C'est "
-"fantastique !"
+"port=8080' target='_blank' rel='noopener noreferrer'>NabBlockly</a> pour "
+"apprendre à coder avec Nabaztag. C'est fantastique !"
 
-#: templates/nabweb/index.html:23 templates/nabweb/index.html:28
+#: templates/nabweb/index.html:24 templates/nabweb/index.html:29
 msgid "Language"
 msgstr "Langue"
 
-#: templates/nabweb/index.html:26
+#: templates/nabweb/index.html:27
 msgid ""
 "The language is used by services with recorded sounds. U.S. English and "
 "British English are based on distinct voices."
@@ -172,11 +322,11 @@ msgstr ""
 "La langue est utilisée par les services avec des sons enregistrés. Une "
 "nouvelle façon d'apprendre des langues étrangères !"
 
-#: templates/nabweb/index.html:41
+#: templates/nabweb/index.html:42
 msgid "Save"
 msgstr "Enregistrer"
 
-#: templates/nabweb/index.html:42
+#: templates/nabweb/index.html:43
 msgid "Reset"
 msgstr "Annuler"
 

--- a/nabweb/templates/nabweb/_base.html
+++ b/nabweb/templates/nabweb/_base.html
@@ -34,7 +34,7 @@
           <li><a class="nav-link{% if request.path == '/rfid/' %} active{% endif %}" href="{% if request.path == '/rfid/' %}#{% else %}/rfid/{% endif %}">{% trans "RFID" %}{% if request.path == '/rfid/' %}  <span class="sr-only">{% trans "(current)" %}</span>{% endif %}</a></li>
           <li><a class="nav-link{% if request.path == '/system-info/' %} active{% endif %}" href="{% if request.path == '/system-info/' %}#{% else %}/system-info/{% endif %}">{% trans "System Information" %}{% if request.path == '/system-info/' %}  <span class="sr-only">{% trans "(current)" %}</span>{% endif %}</a></li>
           <li><a class="nav-link upgrade-link{% if request.path == '/upgrade/' %} active{% endif %}" href="{% if request.path == '/upgrade/' %}#{% else %}/upgrade/{% endif %}">{% trans "Upgrade" %} <span class="badge badge-info"></span>{% if request.path == '/upgrade/' %}  <span class="sr-only">{% trans "(current)" %}</span>{% endif %}</a></li>
-          <li><a class="nav-link" href="https://tagtagtag.fr/help.html" target="_new">{% trans "Help!" %}  </a></li>
+          <li><a class="nav-link{% if request.path == '/help/' %} active{% endif %}" target='_blank' href="{% if request.path == '/help/' %}#{% else %}/help/{% endif %}">{% trans "Help" %}{% if request.path == '/help/' %}  <span class="sr-only">{% trans "(current)" %}</span>{% endif %}</a></li>
         </ul>
         <ul class="nav navbar-nav navbar-right">
           <li><a class="nav-link pull-right" href="https://github.com/nabaztag2018/pynab" target="_blank" rel="noopener noreferrer" aria-label="GitHub"><img src="{% static "nabweb/images/GitHub-Mark-32px.png" %}" title="GitHub" width="20" height="20" /></a></li>

--- a/nabweb/templates/nabweb/_help.html
+++ b/nabweb/templates/nabweb/_help.html
@@ -41,7 +41,7 @@
       </button>
       <div class="collapse navbar-collapse" id="navbarSupportedContent">
         <ul class="navbar-nav mr-auto">
-          <li><a class="nav-link" href="https://tagtagtag.fr/help.html" target="_new">{% trans "Help!" %}  </a></li>
+          <li><a class="nav-link{% if request.path == '/help/' %} active{% endif %}" href="{% if request.path == '/help/' %}#"{% else %}/help/"{% endif %}>{% trans "Home" %}{% if request.path == '/help/' %}  <span class="sr-only">{% trans "(current)" %}</span>{% endif %}</a></li>
         </ul>
         <ul class="nav navbar-nav navbar-right">
           <li><a class="nav-link pull-right" href="https://github.com/nabaztag2018/pynab" target="_blank" rel="noopener noreferrer" aria-label="GitHub"><img src="{% static "nabweb/images/GitHub-Mark-32px.png" %}" title="GitHub" width="20" height="20" /></a></li>

--- a/nabweb/templates/nabweb/help.html
+++ b/nabweb/templates/nabweb/help.html
@@ -1,0 +1,27 @@
+{% extends 'nabweb/_help.html' %}
+{% load i18n %}
+{% block subtitle %}{% trans "Home" %}{% endblock %}
+{% block content %}
+  <div class="jumbotron">
+    <div class="container">
+      <h1 class="display-3">{% trans "Nabaztag help" %}</h1>
+      <hr class="my-4">
+      <p class="lead">{% trans "On your rabbit" %}</p>
+      <p>{% trans "<b>The " %}<a href='/help/weather' title='{% trans "The weather forecast visual animations" %}'>{% trans "weather forecast visual animations" %}</b></a>.</p>
+<!-- uncomment once available...
+      <p>{% trans "<b>The " %}<a href='/help/airquality' title='{% trans "The air quality visual animations" %}'>{% trans "air quality visual animations" %}</b></a>.</p>
+-->
+      <p id="asr"><b>{% trans "Talking to the rabbit (speech recognition)" %}</b><br>{% trans "You need to push and hold the button on the rabbit's head long enough to hear a 'beep', then wait a couple of seconds and speak. When you are done just release the button." %}<br>{% trans "The speech processing is done locally and the answer should come shortly!" %}</p>
+      <p><b>{% trans "Reboot or shutdown the rabbit" %}</b><br>{% blocktrans %}You can do this cleanly by using the <kbd class="btn-warning">Reboot</kbd> or <kbd class="btn-danger">Shutdown</kbd> buttons on the <a  target='_parent' href='/system-info/'>System information</a> tab of the configuration page.{% endblocktrans %}<br>{% trans "As a last resort, you can also shutdown the rabbit by pushing its head button quickly three times in a row." %}</p>
+     <hr class="my-4">
+      <p class="lead">{% trans "On the Internet" %}</p>
+      <p><b>{% trans "<a target='_blank' href='https://tinyletter.com/nabaztag' rel='noopener noreferrer'>Nabaztag is back!</a>" %}</b><br>{% trans "Subscribe to the newsletter." %}</p>
+      <p><b>{% trans "The <a target='_blank' href='https://www.tagtagtag.fr/forum/' rel='noopener noreferrer'>Tag:Tag:Tag user forum</a>" %}</b><br>{% trans "Share your problems and solutions with other rabbit breeders." %}</p>
+      <p><b>{% trans "The <a target='_blank' href='https://github.com/nabaztag2018/pynab/#readme' rel='noopener noreferrer'>GitHub repository</a>" %}</b><br>{% trans "Report bugs or contribute to the project with other developers." %}</p>
+      <p><b>{% trans "<a target='_blank' href='https://twitter.com/nabaztagtagtag' rel='noopener noreferrer'>Nabaztag on Twitter</a>" %}</b></p>
+      <p><b>{% trans "The <a target='_blank' href='https://www.instructables.com/member/tagtagtag/' rel='noopener noreferrer'>TagTagTag assembly instructions</a>" %}</b><br>{% trans "The open heart operation to transplant the card into your rabbit. At this stage you probably do not need this anymore..." %}</p>
+      <p><b>{% trans "<a target='_blank' href='https://www.ulule.com/le-retour-du-retour-du-nabaztag/' rel='noopener noreferrer'>Nabaztag is BackBack</a>" %}</b><br>{% trans "Some project history..." %}</p>
+      <hr class="my-4">
+    </div>
+  </div>
+{% endblock %}

--- a/nabweb/templates/nabweb/index.html
+++ b/nabweb/templates/nabweb/index.html
@@ -5,17 +5,18 @@
   <div class="jumbotron">
     <div class="container">
       <h1 class="display-3">{% trans "Nabaztag configuration" %}</h1>
-      <p class="lead">{% trans "You're currently deeply connected with your inner rabbit." %}</p>
+      <p class="lead">{% trans "You are currently connected to your rabbit." %}</p>
       <hr class="my-4">
-      <p>{% trans "First, make sure the language is properly configured below. Maybe create an account to connect your Nabaztag to <a href='https://mstdn.fr/auth/sign_up'>Mastodon</a> where it will join fellow rabbits <small>(for now, this is only used by ear communion service)</small>." %}</p>
-      <p>{% trans "Eventually, explore top navigation bar to configure <a href='/services/'>Nabaztag services</a>, <a href='/upgrade/'>upgrade software</a> or even visit the <a target='_blank' href='https://github.com/nabaztag2018/pynab' rel='noopener noreferrer'>GitHub repository</a> to start hacking, adding features or simply report bugs." %}</p>
+      <p>{% trans "First, make sure the language is properly configured below." %}<br>{% trans "Then maybe create an account to connect your Nabaztag to <a target='_blank' href='https://joinmastodon.org' rel='noopener noreferrer'>Mastodon</a> where it may join fellow rabbits <small>(for now, this is only used by ear communion service)</small>." %}</p>
+      <p>{% trans "Eventually, explore the top navigation bar to configure <a href='/services/'>Nabaztag services</a> or <a href='/rfid/'>RFID tags</a>, <a href='/upgrade/'>upgrade software</a>, <a target='_blank' href='/help/'>get help</a> or even visit the <a target='_blank' href='https://github.com/nabaztag2018/pynab' rel='noopener noreferrer'>GitHub repository</a> to start hacking, adding features or simply report bugs." %}</p>
 
-      <p>{% trans "You can trigger some services with your voice. The processing is done locally and you need to push the button long enough to hear a 'bip' (keep the button pushed), then wait a couple of seconds (We'll have a look at this later!) then speak and when you're done just release the button. Your service should be played shortly!" %}</p>
-      <p>{% trans "And don't forget to try <a href='/' onclick='javascript:event.target.port=8080' target='_blank' rel='noopener noreferrer'>Nabblocky</a> and learn how to code with Nabaztag. It's fantastic." %}</p>
+      <p>{% trans "You can also trigger some services with your voice by pushing and holding the button on the rabbit's head." %}</p>
+      <hr class="my-4">
+      <p>{% trans "And do not forget to try <a href='/' onclick='javascript:event.target.port=8080' target='_blank' rel='noopener noreferrer'>NabBlockly</a> and learn how to code with Nabaztag. It's fantastic." %}</p>
     </div>
   </div>
-  <div class="row justify-content-center">
-    <div class="col-xl-8 col-lg-10 col-md-10 mb-3">
+  <div class="row">
+    <div class="col-md-6 mb-3">
       <div class="card" id="language-settings">
         <form method="post" action="/">
           {% csrf_token %}
@@ -46,12 +47,16 @@
         </form>
       </div>
     </div>
-  </div>
   {% for service in services %}
-    <div class="row justify-content-center">
-      <div class="settings col-xl-8 col-lg-10 col-md-10 mb-3" data-url="/{{ service }}/settings"></div>
+    {% if forloop.counter|divisibleby:2 %}
+    <div class="row">
+    {% endif %}
+      <div class="settings col-md-6 mb-3" data-url="/{{ service }}/settings"></div>
+    {% if not forloop.counter|divisibleby:2 or forloop.last %}
     </div>
+    {% endif %}
   {% endfor %}
+  </div>
   <script type="text/javascript">
   $(function() {
     var form = $('#language-settings form');

--- a/nabweb/urls.py
+++ b/nabweb/urls.py
@@ -74,9 +74,21 @@ urlpatterns = [
         name="nabweb.upgrade.checknow",
     ),
     path(
+        "help/",
+        TemplateView.as_view(template_name="nabweb/help.html"),
+        name="nabweb.help",
+    ),
+    path(
         "help/weather",
         TemplateView.as_view(template_name="nabweatherd/animations_help.html"),
         name="nabweatherd.help.animations",
+    ),
+    path(
+        "help/airquality",
+        TemplateView.as_view(
+            template_name="nabairqualityd/animations_help.html"
+        ),
+        name="nabairqualityd.help.animations",
     ),
 ]
 


### PR DESCRIPTION
Resolves #16.
Optimize screen real estate on nabweb home page by having services on 2 columns as on services page.
Slightly cleanup/amend presentation text, while keeping the original spirit.
Correct Mastodon reference to make it more generic (https://joinmastodon.org).

Add new help page (linked from `Help` menu) with local content and appropriate internet links.
Together with PRs #248 and #250, this should mostly resolve #16.
