### PR TITLE
Revamp system information and upgrade pages

### DIFF
--- a/nabweb/locale/fr_FR/LC_MESSAGES/django.po
+++ b/nabweb/locale/fr_FR/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-28 18:45+0200\n"
+"POT-Creation-Date: 2021-06-01 10:33+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -73,7 +73,7 @@ msgstr "Services"
 
 #: templates/nabweb/_base.html:34 templates/nabweb/rfid/index.html:4
 #: templates/nabweb/rfid/index.html:26
-#: templates/nabweb/system-info/index.html:100
+#: templates/nabweb/system-info/index.html:104
 msgid "RFID"
 msgstr "RFID"
 
@@ -341,15 +341,15 @@ msgstr ""
 "remplacer?"
 
 #: templates/nabweb/rfid/index.html:16
-#: templates/nabweb/system-info/index.html:95
-#: templates/nabweb/system-info/index.html:101
+#: templates/nabweb/system-info/index.html:99
+#: templates/nabweb/system-info/index.html:105
 #: templates/nabweb/upgrade/index.html:30
 msgid "Yes"
 msgstr "Oui"
 
 #: templates/nabweb/rfid/index.html:17
-#: templates/nabweb/system-info/index.html:95
-#: templates/nabweb/system-info/index.html:101
+#: templates/nabweb/system-info/index.html:99
+#: templates/nabweb/system-info/index.html:105
 #: templates/nabweb/upgrade/index.html:31
 msgid "No"
 msgstr "Non"
@@ -615,125 +615,129 @@ msgstr "Nom d'hôte"
 msgid "IP address"
 msgstr "Adresse IP"
 
-#: templates/nabweb/system-info/index.html:20
-#: templates/nabweb/system-info/index.html:63
+#: templates/nabweb/system-info/index.html:21
+msgid "Wireless network"
+msgstr "Réseau sans fil"
+
+#: templates/nabweb/system-info/index.html:24
+#: templates/nabweb/system-info/index.html:67
 msgid "Uptime"
 msgstr "Levé depuis"
 
-#: templates/nabweb/system-info/index.html:22
+#: templates/nabweb/system-info/index.html:26
 msgid "SSH (Secure shell)"
 msgstr "SSH (shell sécurisé)"
 
-#: templates/nabweb/system-info/index.html:23
+#: templates/nabweb/system-info/index.html:27
 msgid "Enabled with default password"
 msgstr "Activé avec le mot de passe par défaut"
 
-#: templates/nabweb/system-info/index.html:23
+#: templates/nabweb/system-info/index.html:27
 msgid "Enabled"
 msgstr "Activé"
 
-#: templates/nabweb/system-info/index.html:23
+#: templates/nabweb/system-info/index.html:27
 msgid "Disabled"
 msgstr "Désactivé"
 
-#: templates/nabweb/system-info/index.html:26
+#: templates/nabweb/system-info/index.html:30
 msgid "Maintenance"
 msgstr "Maintenance"
 
-#: templates/nabweb/system-info/index.html:28
-#: templates/nabweb/system-info/index.html:118
-#: templates/nabweb/system-info/index.html:128
+#: templates/nabweb/system-info/index.html:32
+#: templates/nabweb/system-info/index.html:122
+#: templates/nabweb/system-info/index.html:132
 msgid "Reboot"
 msgstr "Redémarrer"
 
-#: templates/nabweb/system-info/index.html:29
-#: templates/nabweb/system-info/index.html:137
-#: templates/nabweb/system-info/index.html:147
+#: templates/nabweb/system-info/index.html:33
+#: templates/nabweb/system-info/index.html:141
+#: templates/nabweb/system-info/index.html:151
 msgid "Shutdown"
 msgstr "Arrêter"
 
-#: templates/nabweb/system-info/index.html:35
+#: templates/nabweb/system-info/index.html:39
 msgid "<b>Reboot is in progress!</b>"
 msgstr "<b>Le redémarrage est en cours!</b>"
 
-#: templates/nabweb/system-info/index.html:41
+#: templates/nabweb/system-info/index.html:45
 msgid "<b>Shutdown is in progress!</b>"
 msgstr "<b>L'arrêt est en cours!</b>"
 
-#: templates/nabweb/system-info/index.html:41
+#: templates/nabweb/system-info/index.html:45
 msgid "Please wait at least 10 seconds before unplugging the power cable."
 msgstr ""
 "Veuillez attendre au moins 10 secondes avant de débrancher le cable "
 "d'alimentation."
 
-#: templates/nabweb/system-info/index.html:52
+#: templates/nabweb/system-info/index.html:56
 msgid "Nabd daemon"
 msgstr "Processus Nabd"
 
-#: templates/nabweb/system-info/index.html:61
+#: templates/nabweb/system-info/index.html:65
 msgid "State"
 msgstr "État"
 
-#: templates/nabweb/system-info/index.html:65
+#: templates/nabweb/system-info/index.html:69
 msgid "Clients (including website)"
-msgstr "Clients (y compris ce site Web)"
+msgstr "Clients (y compris le site Web)"
 
-#: templates/nabweb/system-info/index.html:77
+#: templates/nabweb/system-info/index.html:81
 msgid "Hardware"
 msgstr "Matériel"
 
-#: templates/nabweb/system-info/index.html:81
+#: templates/nabweb/system-info/index.html:85
 msgid "Computer"
 msgstr "Ordinateur"
 
-#: templates/nabweb/system-info/index.html:90
+#: templates/nabweb/system-info/index.html:94
 msgid "Hat card"
 msgstr "Carte chapeau"
 
-#: templates/nabweb/system-info/index.html:92
+#: templates/nabweb/system-info/index.html:96
 msgid "Sound card"
 msgstr "Carte son"
 
-#: templates/nabweb/system-info/index.html:94
+#: templates/nabweb/system-info/index.html:98
 msgid "Sound input"
 msgstr "Entrée son"
 
-#: templates/nabweb/system-info/index.html:96
+#: templates/nabweb/system-info/index.html:100
 msgid "Left ear"
 msgstr "Oreille gauche"
 
-#: templates/nabweb/system-info/index.html:98
+#: templates/nabweb/system-info/index.html:102
 msgid "Right ear"
 msgstr "Oreille droite"
 
-#: templates/nabweb/system-info/index.html:105
+#: templates/nabweb/system-info/index.html:109
 msgid "Hardware test"
 msgstr "Test matériel"
 
-#: templates/nabweb/system-info/index.html:107
+#: templates/nabweb/system-info/index.html:111
 msgid "LEDs"
 msgstr "LEDs"
 
-#: templates/nabweb/system-info/index.html:108
+#: templates/nabweb/system-info/index.html:112
 msgid "Ears"
 msgstr "Oreilles"
 
-#: templates/nabweb/system-info/index.html:124
+#: templates/nabweb/system-info/index.html:128
 msgid "You are about to <b>reboot</b> the Raspberry Pi Linux system."
 msgstr ""
 "Vous êtes sur le point de <b>redémarrer</b> le système Linux du Raspberry Pi."
 
-#: templates/nabweb/system-info/index.html:124
-#: templates/nabweb/system-info/index.html:143
+#: templates/nabweb/system-info/index.html:128
+#: templates/nabweb/system-info/index.html:147
 msgid "Do you want to proceed?"
 msgstr "Voulez-vous continuer?"
 
-#: templates/nabweb/system-info/index.html:127
-#: templates/nabweb/system-info/index.html:146
+#: templates/nabweb/system-info/index.html:131
+#: templates/nabweb/system-info/index.html:150
 msgid "Cancel"
 msgstr "Annuler"
 
-#: templates/nabweb/system-info/index.html:143
+#: templates/nabweb/system-info/index.html:147
 msgid "You are about to <b>shutdown</b> the Raspberry Pi Linux system."
 msgstr ""
 "Vous êtes sur le point d'<b>éteindre</b> le système Linux du Raspberry Pi."
@@ -744,19 +748,19 @@ msgstr "À jour"
 
 #: templates/nabweb/upgrade/_repository.html:17
 msgid "Branch:"
-msgstr "Branche"
+msgstr "Branche :"
 
 #: templates/nabweb/upgrade/_repository.html:20
 msgid "Version:"
-msgstr "Version"
+msgstr "Version :"
 
 #: templates/nabweb/upgrade/_repository.html:23
 msgid "You have unpushed local commits in this repository."
-msgstr "Vous avez des commits locaux non publiés"
+msgstr "Vous avez des commits locaux non publiés dans ce référentiel."
 
 #: templates/nabweb/upgrade/_repository.html:26
 msgid "You have local changes in this repository."
-msgstr "Vous avez des modifications locales dans ce repository"
+msgstr "Vous avez des modifications locales dans ce référentiel."
 
 #: templates/nabweb/upgrade/index.html:9
 msgid "Upgrade in progress"
@@ -764,7 +768,7 @@ msgstr "Mise à jour en cours"
 
 #: templates/nabweb/upgrade/index.html:15
 msgid "Upgrade is currently in progress..."
-msgstr "La mise à jour est en cours"
+msgstr "La mise à jour est en cours ..."
 
 #: templates/nabweb/upgrade/index.html:24
 msgid "Local changes"
@@ -775,64 +779,74 @@ msgid ""
 "Local changes have been detected in at least one repository. Automatic "
 "upgrade may fail. Are you sure you want to proceed?"
 msgstr ""
-"Des modifications locales ont été détectées dans au moins un repository. La "
+"Des modifications locales ont été détectées dans au moins un référentiel. La "
 "mise à jour automatique risque d'échouer. Souhaitez-vous néanmoins continuer?"
 
 #: templates/nabweb/upgrade/index.html:43
 msgid ""
-"Through this interface, you can upgrade your Nabaztag software (provided "
-"that it is connected to the internet). This can take up a while depending on "
-"the size and the scope of the update : <b>don't restart your rabbit before "
-"the process is finished</b>."
+"Through this interface, you can upgrade your Nabaztag software (provided it "
+"is connected to the internet). This may take a while depending on the size "
+"and the scope of the update. <strong>Do not restart your rabbit before the "
+"process is finished</strong>."
 msgstr ""
-"Grâce à cette interface, vous pouvez mettre à jour votre Nabaztag (mais il "
-"doit être connecté à Internet). Attention, le process peut être assez long "
-"en fonction de ce qu'il y a à faire. <b>Attendez la fin de la mise à jour "
-"sinon on ne répond plus de rien</b>."
+"Grâce à cette interface, vous pouvez mettre à jour le logiciel de votre "
+"Nabaztag (s'il est connecté à Internet). Attention, cela peut être assez "
+"long en fonction de ce qu'il y a à faire. <strong>Attendez la fin de la "
+"mise à jour sinon on ne répond plus de rien</strong>."
 
 #: templates/nabweb/upgrade/index.html:45
 msgid ""
-"Your Nabaztag is apparently tracking the master branch. Please note that web-"
-"based upgrade mechanism may fail and require that you connect over SSH."
+"You can switch to the Pynab <b>master</b> branch to benefit from changes "
+"between releases, however this is not for the faint-hearted and requires "
+"good command of <a href='https://www.raspberrypi.org/documentation/remote-"
+"access/ssh/' target='_blanck' rel='noopener noreferrer'>SSH</a> and <a "
+"href='https://git-scm.com/docs/' target='_blanck' rel='noopener "
+"noreferrer'>Git</a>."
 msgstr ""
-"Attention, apparemment, votre Nabaztag est monté sur la branche master : la "
-"mise à jour avec l'interface web peut échouer. Et là, que la force soit avec "
-"vous, il faudra terminer en SSH."
+"Vous pouvez basculer sur la branche <b>master</b> de Pynab pour avoir les "
+"dernières nouveautés, mais ceci suppose que vous n'avez pas peur de <a "
+"href='https://www.raspberrypi.org/documentation/remote-access/ssh/' "
+"target='_blanck' rel='noopener noreferrer'>SSH</a> et de <a href='https://"
+"git-scm.com/docs/' target='_blanck' rel='noopener noreferrer'>Git</a>."
 
-#: templates/nabweb/upgrade/index.html:48
+#: templates/nabweb/upgrade/index.html:47
 msgid ""
-"You can switch to master branch to benefit from changes between releases, "
-"however this is not for the faint-hearted and requires good command of <a "
-"href='https://www.raspberrypi.org/documentation/remote-access/ssh/' "
-"target='_blanck'>SSH</a> and <a href='https://en.wikipedia.org/wiki/Git' "
-"target='_blanck'>Git</a>."
+"Your Nabaztag is using a purely local Pynab branch. Upgrade is not "
+"applicable."
 msgstr ""
-"Vous pouvez sauter sur la branche master pour avoir les dernières "
-"nouveautés, mais attention j'espère juste que vous n'avez pas peur de <a "
-"href='https://www.raspberrypi.org/documentation/remote-access/ssh/' "
-"target='_blanck'>SSH</a> et de  <a href='https://en.wikipedia.org/wiki/Git' "
-"target='_blanck'>Git</a>."
+"Votre Nabaztag utilise une branche purement locale de Pynab. Pas de mise à "
+"jour dans ce cas."
 
-#: templates/nabweb/upgrade/index.html:50
+#: templates/nabweb/upgrade/index.html:49
+msgid ""
+"Your Nabaztag is apparently not tracking the Pynab <b>release</b> branch. "
+"Please note that web-based upgrade mechanism may fail and require that you "
+"connect over SSH."
+msgstr ""
+"Attention, apparemment, votre Nabaztag ne suit pas la branche <b>release</b> "
+"de Pynab : la mise à jour avec l'interface web peut échouer. Et là, que la "
+"force soit avec vous, il faudra terminer en SSH."
+
+#: templates/nabweb/upgrade/index.html:51
 msgid "Current versions"
-msgstr "Version actuelle"
+msgstr "Versions actuelles"
 
-#: templates/nabweb/upgrade/index.html:73
+#: templates/nabweb/upgrade/index.html:74
 msgid "Last check:"
 msgstr "Dernière vérification :"
 
-#: templates/nabweb/upgrade/index.html:73
+#: templates/nabweb/upgrade/index.html:74
 #, python-format
 msgid "%(last_check_since)s ago"
 msgstr "il y a %(last_check_since)s"
 
-#: templates/nabweb/upgrade/index.html:78
+#: templates/nabweb/upgrade/index.html:79
 msgid "Check now"
 msgstr "Vérifier maintenant"
 
-#: templates/nabweb/upgrade/index.html:79
+#: templates/nabweb/upgrade/index.html:80
 msgid "Upgrade now"
-msgstr "Mise à jour"
+msgstr "Mettre à jour"
 
 #: templatetags/duration_filter.py:12
 msgid "less than one minute"

--- a/nabweb/templates/nabweb/system-info/index.html
+++ b/nabweb/templates/nabweb/system-info/index.html
@@ -7,7 +7,7 @@
     <div class="col-xl-8 col-lg-10 col-md-10 mb-3">
       <div class="card">
         <div class="card-header">
-          <h5 class="card-title">{% trans "Raspberry Pi OS" %}</h5>
+          <h5 class="card-title"><a class="help-link" href='https://www.raspberrypi.org/software/operating-systems/#raspberry-pi-os-32-bit' target='_blank' rel='noopener noreferrer'>{% trans "Raspberry Pi OS" %}</a></h5>
         </div>
         <div class="card-body">
           <dl class="row">
@@ -17,9 +17,13 @@
             <dd class="col-sm-8">{{ os.hostname }}</dd>
             <dt class="col-sm-4">{% trans "IP address" %}</dt>
             <dd class="col-sm-8">{{ os.address }}</dd>
+            {% if os.network %}
+            <dt class="col-sm-4"><a class="help-link" href='https://www.raspberrypi.org/documentation/configuration/wireless/' target='_blank' rel='noopener noreferrer'>{% trans "Wireless network" %}</a></dt>
+            <dd class="col-sm-8">{{ os.network }}</dd>
+            {% endif %}
             <dt class="col-sm-4">{% trans "Uptime" %}</dt>
             <dd class="col-sm-8">{{ os.uptime|duration }}</dd>
-            <dt class="col-sm-4"><a class="help-link" href="https://www.raspberrypi.org/documentation/remote-access/ssh/" >{% trans "SSH (Secure shell)" %}</a></dt>
+            <dt class="col-sm-4"><a class="help-link" href='https://www.raspberrypi.org/documentation/remote-access/ssh/' target='_blank' rel='noopener noreferrer'>{% trans "SSH (Secure shell)" %}</a></dt>
             <dd class="col-sm-8">{% if os.ssh == "sshwarn" %}<span class="text-danger">{% trans "Enabled with default password" %}</span>{% else %}{% if os.ssh == "active" %}{% trans "Enabled" %}{% else %}{% trans "Disabled" %}{% endif %}{% endif %}</dd>
           </dl>
           <dl class="row">

--- a/nabweb/templates/nabweb/upgrade/index.html
+++ b/nabweb/templates/nabweb/upgrade/index.html
@@ -40,12 +40,13 @@
           <h5 class="card-title">{% trans "Upgrade" %}</h5>
         </div>
         <div class="card-body">
-          <p>{% trans "Through this interface, you can upgrade your Nabaztag software (provided that it is connected to the internet). This can take up a while depending on the size and the scope of the update : <b>don't restart your rabbit before the process is finished</b>." %}</p>
-          {% if pynab.upstream_branch == "origin/master" %}
-          <p>{% trans "Your Nabaztag is apparently tracking the master branch. Please note that web-based upgrade mechanism may fail and require that you connect over SSH." %}</p>
-          {% endif %}
+          <p>{% blocktrans %}Through this interface, you can upgrade your Nabaztag software (provided it is connected to the internet). This may take a while depending on the size and the scope of the update. <strong>Do not restart your rabbit before the process is finished</strong>.{% endblocktrans %}</p>
           {% if pynab.upstream_branch == "origin/release" %}
-          <p class="text-secondary">{% trans "You can switch to master branch to benefit from changes between releases, however this is not for the faint-hearted and requires good command of <a href='https://www.raspberrypi.org/documentation/remote-access/ssh/' target='_blanck'>SSH</a> and <a href='https://en.wikipedia.org/wiki/Git' target='_blanck'>Git</a>." %}</p>
+          <p class="text-secondary">{% trans "You can switch to the Pynab <b>master</b> branch to benefit from changes between releases, however this is not for the faint-hearted and requires good command of <a href='https://www.raspberrypi.org/documentation/remote-access/ssh/' target='_blanck' rel='noopener noreferrer'>SSH</a> and <a href='https://git-scm.com/docs/' target='_blanck' rel='noopener noreferrer'>Git</a>." %}</p>
+          {% elif pynab.upstream_branch == "" %}
+          <p class="text-warning">{% trans "Your Nabaztag is using a purely local Pynab branch. Upgrade is not applicable." %}</p>
+          {% else %}
+          <p class="text-warning">{% trans "Your Nabaztag is apparently not tracking the Pynab <b>release</b> branch. Please note that web-based upgrade mechanism may fail and require that you connect over SSH." %}</p>
           {% endif %}
           <h5>{% trans "Current versions" %}</h5>
           {% include "nabweb/upgrade/_repository.html" with repo=pynab %}


### PR DESCRIPTION
System information page:
- add kernel build# to OS version information;
 -retrieve kernel information using `platform` module, rather than `uname` command;
 - add wireless network (using `iwgetid` command);
 - add help links.
 
Upgrade page:
 - improve(?) wording/translations.
 - correct help link for Git.