### PR TITLE
Cleanup unhandled exceptions handling to avoid polluting system logs with tracebacks

### DIFF
--- a/nabairqualityd/aqicn.py
+++ b/nabairqualityd/aqicn.py
@@ -84,7 +84,7 @@ class aqicnClient:
             self._city = city
 
         except Exception as err:
-            logging.critical(f"connection error: {err}")
+            logging.error(f"error: {err}")
             raise aqicnError(err)
 
     def get_data(self):

--- a/nabcommon/nabservice.py
+++ b/nabcommon/nabservice.py
@@ -202,6 +202,11 @@ class NabService(ABC):
             print(error_msg)
             logging.critical(error_msg)
             exit(1)
+        except Exception:
+            error_msg = f"Unhandled error: {sys.exc_info()[0]}"
+            print(error_msg)
+            logging.critical(error_msg)
+            exit(3)
 
 
 class NabRecurrentService(NabService, ABC):

--- a/nabweatherd/nabweatherd.py
+++ b/nabweatherd/nabweatherd.py
@@ -14,11 +14,10 @@ from nabcommon.nabservice import NabInfoService
 from . import rfid_data
 
 
-class meteoError(Exception):
-    """Raise when errors occur while fetching or parsing data"""
-
-
 class NabWeatherd(NabInfoService):
+    class meteoError(Exception):
+        """Raise when errors occur while fetching or parsing data"""
+
     UNIT_CELSIUS = 1
     UNIT_FARENHEIT = 2
 
@@ -410,8 +409,8 @@ class NabWeatherd(NabInfoService):
             data = my_place_weather_forecast.daily_forecast
             logging.debug(f"data: {data}")
         except Exception as err:
-            logging.critical(f"connection error: {err}")
-            raise meteoError(err)
+            logging.error(f"error: {err}")
+            raise self.meteoError(err)
 
         # Rain info
         next_rain = False


### PR DESCRIPTION
Related to #223. Followup to #266.
Add a global handler for unhandled service exceptions (for example connection errors in `nabairqualityd` and `nabweatherd`), to avoid polluting system logs (`/var/log/syslog` `/var/log/daemon.log`) with tracebacks.