### PR TITLE
Use raspios_lite:2021-05-07 base image

### DIFF
--- a/.github/workflows/arm-runner.yml
+++ b/.github/workflows/arm-runner.yml
@@ -1,22 +1,22 @@
-name: build (qemu)
+name: 🏗️  Build
 on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Run tests in chroot
+    - name: Run tests in chroot environment
       uses: pguyot/arm-runner-action@v1
       id: arm_runner_tests
       with:
         image_additional_mb: 3584
-        base_image: 'raspios_lite:2021-03-04'
+        base_image: 'raspios_lite:2021-05-07'
         cpu: 'arm1176'
         copy_repository_path: /home/pi/pynab
         commands: |
             sudo chown -R pi:pi /home/pi/pynab
             sudo apt-get update -y
-            sudo apt-get install --no-install-recommends -y postgresql libpq-dev git python3 python3-venv python3-dev gettext nginx openssl libssl-dev libffi-dev libmpg123-dev libasound2-dev libatlas-base-dev libgfortran3 libopenblas-dev liblapack-dev gfortran zram-tools
+            sudo apt-get install --no-install-recommends -y postgresql libpq-dev git python3 python3-venv python3-dev gettext nginx openssl libssl-dev libffi-dev libmpg123-dev libasound2-dev libatlas-base-dev libgfortran3 libopenblas-dev liblapack-dev zram-tools
             sudo mkdir -p /run/systemd/timesync/ && sudo touch /run/systemd/timesync/synchronized
             sudo -u pi taskset -c 0 /bin/bash install.sh ci-chroot-test
     - name: Upload image if tests failed
@@ -43,12 +43,12 @@ jobs:
         else
           echo ::set-output name=LOCAL_BRANCH::${GITHUB_REF/refs\/heads\//}
         fi
-    - name: Create a release image using chroot
+    - name: Create a release image in chroot environment
       uses: pguyot/arm-runner-action@v1
       id: arm_runner_install
       with:
         image_additional_mb: 3584
-        base_image: 'raspios_lite:2021-03-04'
+        base_image: 'raspios_lite:2021-05-07'
         cpu: 'arm1176'
         commands: |
             echo GITHUB_BRANCH=${{ steps.image_and_branch_name.outputs.LOCAL_BRANCH }}
@@ -57,7 +57,7 @@ jobs:
             sudo rm -rf /pynab
             sudo apt-get autoremove -y
             sudo apt-get clean
-    - name: Compress the release image with pishrink
+    - name: Compress the release image with PiShrink
       run: |
         mv ${{ steps.arm_runner_install.outputs.image }} pynab-${{ steps.image_and_branch_name.outputs.IMAGE_NAME_SUFFIX }}.img
         wget https://raw.githubusercontent.com/Drewsif/PiShrink/fa3c7a27406e7c0a1c7b8688e330f14a766be1ba/pishrink.sh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,62 +1,60 @@
----
-name: 🌙 Nightly Builder
+name: 🌙 Nightly build
 on:
   schedule:
     - cron: "0 0 * * *"
 
 jobs:
   check_date:
-    name: 🧐 Check latest commit
+    name: Check latest commit
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.should_run.outputs.SHOULD_RUN }}
 
     steps:
-      - name: ⬇ Checkout pynab
+      - name: Checkout pynab
         uses: actions/checkout@v2
         with:
           repository: ${{ github.repository }}
 
-      - name: 🖨 Print latest commit
+      - name: Print latest commit
         shell: bash
         run: |
           echo "Last commit: ${{ github.sha }}"
 
-      - name: 🔍 Check latest commit is less than a day
+      - name: Check if latest commit is less than a day old
         id: should_run
-        continue-on-error: true
         shell: bash
         run: |
-          test -z $(git rev-list --after="24 hours" ${{ github.sha }}) && echo "::set-output name=SHOULD_RUN::false"
+          test -z $(git rev-list --after="24 hours" ${{ github.sha }}) && echo "::set-output name=SHOULD_RUN::false" || echo "::set-output name=SHOULD_RUN::true"
 
   test_suite:
-    name: 🧪 Test suite in Raspberry Pi OS Lite
+    name: Run test suite
     runs-on: ubuntu-latest
     needs: check_date
-    if: ${{ needs.check_date.outputs.SHOULD_RUN != 'false' }}
+    if: ${{ needs.check_date.outputs.SHOULD_RUN == 'true' }}
 
     steps:
-      - name: ⬇ Checkout pynab
+      - name: Checkout pynab
         uses: actions/checkout@v2
         with:
           repository: ${{ github.repository }}
 
-      - name: 🚀 Run test suite in chroot
+      - name: Run test suite in chroot environment
         uses: pguyot/arm-runner-action@v1
         id: arm_runner_tests
         with:
           image_additional_mb: 3584
-          base_image: 'raspios_lite:2021-03-04'
+          base_image: 'raspios_lite:2021-05-07'
           cpu: 'arm1176'
           copy_repository_path: /home/pi/pynab
           commands: |
             sudo chown -R pi:pi /home/pi/pynab
             sudo apt-get update -y
-            sudo apt-get install --no-install-recommends -y postgresql libpq-dev git python3 python3-venv python3-dev gettext nginx openssl libssl-dev libffi-dev libmpg123-dev libasound2-dev libatlas-base-dev libgfortran3 libopenblas-dev liblapack-dev gfortran zram-tools
+            sudo apt-get install --no-install-recommends -y postgresql libpq-dev git python3 python3-venv python3-dev gettext nginx openssl libssl-dev libffi-dev libmpg123-dev libasound2-dev libatlas-base-dev libgfortran3 libopenblas-dev liblapack-dev zram-tools
             sudo mkdir -p /run/systemd/timesync/ && sudo touch /run/systemd/timesync/synchronized
             sudo -u pi taskset -c 0 /bin/bash install.sh ci-chroot-test
 
-      - name: ⬆ Upload image if tests failed
+      - name: Upload image if tests failed
         uses: actions/upload-artifact@v2
         if: failure()
         with:
@@ -64,30 +62,31 @@ jobs:
           path: ${{ steps.arm_runner_tests.outputs.image }}
 
   build_image:
-    name: 📦 Build Image
+    name: Build Image
     runs-on: ubuntu-latest
     needs: [check_date, test_suite]
-    if: ${{ needs.check_date.outputs.SHOULD_RUN != 'false' }}
+    if: ${{ needs.check_date.outputs.SHOULD_RUN == 'true' }}
 
     steps:
-      - name: ⬇ Checkout pynab
+      - name: Checkout pynab
         uses: actions/checkout@v2
         with:
           repository: ${{ github.repository }}
 
-      - name: 🏗 Define the image name
+      - name: Define the image name
         id: image_and_branch_name
         shell: bash
         run: |
-          echo ::set-output name=IMAGE_NAME_SUFFIX::nightly-$(date +"%Y-%m-%d")
+          nightly_pattern=nightly
+          echo ::set-output name=IMAGE_NAME_SUFFIX::${nightly_pattern}-$(date +"%Y-%m-%d")
           echo ::set-output name=LOCAL_BRANCH::${GITHUB_REF/refs\/heads\//}
 
-      - name: 🔧 Create a release image using chroot
+      - name: Create a release image in chroot environment
         uses: pguyot/arm-runner-action@v1
         id: arm_runner_install
         with:
           image_additional_mb: 3584
-          base_image: 'raspios_lite:2021-03-04'
+          base_image: 'raspios_lite:2021-05-07'
           cpu: 'arm1176'
           commands: |
               echo GITHUB_BRANCH=${{ steps.image_and_branch_name.outputs.LOCAL_BRANCH }}
@@ -97,15 +96,15 @@ jobs:
               sudo apt-get autoremove -y
               sudo apt-get clean
 
-      - name: 🗜️ Compress the release image with PiShrink
+      - name: Compress the release image with PiShrink
         shell: bash
         run: |
           mv ${{ steps.arm_runner_install.outputs.image }} pynab-${{ steps.image_and_branch_name.outputs.IMAGE_NAME_SUFFIX }}.img
-          wget https://raw.githubusercontent.com/Drewsif/PiShrink/HEAD/pishrink.sh
-          sudo bash pishrink.sh -Z -a -p pynab-${{ steps.image_and_branch_name.outputs.IMAGE_NAME_SUFFIX }}.img
+          wget https://raw.githubusercontent.com/Drewsif/PiShrink/fa3c7a27406e7c0a1c7b8688e330f14a766be1ba/pishrink.sh
+          sudo bash pishrink.sh -Z -a pynab-${{ steps.image_and_branch_name.outputs.IMAGE_NAME_SUFFIX }}.img
           ls -lsha
 
-      - name: 🖊 Generate release name
+      - name: Generate release name
         id: release_version
         shell: bash
         run: |
@@ -115,7 +114,7 @@ jobs:
           echo "Release name is: ${pynab_nightly_version}"
           echo "::set-output name=NAME::${pynab_nightly_version}"
 
-      - name: 🦄 Create release with image from master
+      - name: Create release with image from master
         uses: "marvinpinto/action-automatic-releases@v1.1.2"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
@@ -126,21 +125,29 @@ jobs:
           files: pynab-${{ steps.image_and_branch_name.outputs.IMAGE_NAME_SUFFIX }}.img.xz
 
   clean_nightly_releases:
-    name: 🧹 Remove old nightly releases
+    name: Remove old nightly releases
     runs-on: ubuntu-latest
 
     steps:
-      - name: ⬇ Checkout pynab
+      - name: Checkout pynab with tags
         uses: actions/checkout@v2
         with:
-          # ⚠️ repository hosting the nigthly build
+          # repository hosting the nigthly build
           repository: ${{ github.repository }}
+          # all history for tags
+          fetch-depth: 0
 
-      - name: 🧹 Remove old nightly releases
+      - name: Remove old nightly releases
         shell: bash
         run: |
           keep=2
           nightly_pattern=nightly
-          hub release --include-drafts -f "%T (%S) %n" | grep "${nightly_pattern}" | sort -r | sed "1,${keep}d" | awk '{print $1}' | xargs --no-run-if-empty -t -n1 hub release delete
+          origin=origin
+          old_tags=$(git tag -l | (grep "^${nightly_pattern}" ; true) | sort -r | sed "1,${keep}d" | tr '\n' ' ')
+          old_builds=$(hub release --include-drafts | (grep "^${nightly_pattern}" ; true) | sort -r | sed "1,${keep}d" | tr '\n' ' ')
+          echo "Old tags to delete:   ${old_tags}"
+          echo "Old builds to delete: ${old_builds}"
+          echo ${old_builds} | xargs --no-run-if-empty -t -n1 hub release delete
+          echo ${old_tags} | xargs --no-run-if-empty -t git push --delete ${origin}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,4 +1,4 @@
-name: python-lint
+name: ✔️  Python lint
 
 on: [push, pull_request]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: tests
+name: 🧪 Tests
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Resolves #258
Resolves #253.

- Updates GitHub workflows to use **raspios_lite:2021-05-07** base image.
  **Note**: this **depends** on update of GitHub action: https://github.com/pguyot/arm-runner-action/pull/2.
- ~~Also uses `nabooot.service` to ensure `/var/log/nginx `directory exists before `nginx.service` is started.
  This allows to reintroduce -p option to PiShrink when building images.~~