### PR TITLE
nabweatherd/nabairqualityd: Avoid service restart on exception when fetching data

### DIFF
--- a/nabairqualityd/aqicn.py
+++ b/nabairqualityd/aqicn.py
@@ -84,7 +84,6 @@ class aqicnClient:
             self._city = city
 
         except Exception as err:
-            logging.error(f"error: {err}")
             raise aqicnError(err)
 
     def get_data(self):


### PR DESCRIPTION
Catch exception raised when fetching data, log it as `ERROR`, and resume processing with `info_data=None`.

Note: audio forecast then uses `nabweatherd/no-data-error.mp3` / `nabairqualityd/no-data-error.mp3` sound resources.