### PR TITLE
Change Surprise frequency computation, to match original Nabaztag scale

### DIFF
--- a/nabsurprised/locale/fr_FR/LC_MESSAGES/django.po
+++ b/nabsurprised/locale/fr_FR/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-02-12 14:21+0100\n"
+"POT-Creation-Date: 2021-07-17 15:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -84,32 +84,37 @@ msgstr "Fréquence des humeurs"
 
 #: templates/nabsurprised/settings.html:13
 msgctxt "Surprise frequency"
+msgid "Rarely"
+msgstr "Rarement"
+
+#: templates/nabsurprised/settings.html:14
+msgctxt "Surprise frequency"
 msgid "Sometimes"
 msgstr "De temps en temps"
 
-#: templates/nabsurprised/settings.html:14
+#: templates/nabsurprised/settings.html:15
 msgctxt "Surprise frequency"
 msgid "Often"
 msgstr "Souvent"
 
-#: templates/nabsurprised/settings.html:15
+#: templates/nabsurprised/settings.html:16
 msgctxt "Surprise frequency"
 msgid "Very often"
 msgstr "Très souvent"
 
-#: templates/nabsurprised/settings.html:16
+#: templates/nabsurprised/settings.html:17
 msgctxt "Surprise frequency"
-msgid "Disabled"
+msgid "Never"
 msgstr "Jamais"
 
-#: templates/nabsurprised/settings.html:22
+#: templates/nabsurprised/settings.html:23
 msgid "Surprise me now!"
 msgstr "Chatouille"
 
-#: templates/nabsurprised/settings.html:29
+#: templates/nabsurprised/settings.html:30
 msgid "Save"
 msgstr "Enregistrer"
 
-#: templates/nabsurprised/settings.html:30
+#: templates/nabsurprised/settings.html:31
 msgid "Reset"
 msgstr "Annuler"

--- a/nabsurprised/nabsurprised.py
+++ b/nabsurprised/nabsurprised.py
@@ -8,6 +8,14 @@ from . import rfid_data
 
 
 class NabSurprised(NabRandomService):
+    RARELY, SOMETIMES, OFTEN, VERY_OFTEN = 30, 50, 125, 250
+    FREQUENCY_SECONDS = {
+        RARELY: 10800,
+        SOMETIMES: 7200,
+        OFTEN: 3600,
+        VERY_OFTEN: 1200,
+    }
+
     NLU_INTENTS = [
         "nabsurprised/surprise",
         "nabsurprised/carrot",
@@ -61,7 +69,10 @@ class NabSurprised(NabRandomService):
         await self.writer.drain()
 
     def compute_random_delta(self, frequency):
-        return (256 - frequency) * 60 * (random.uniform(0, 255) + 64) / 128
+        key = frequency
+        if key not in NabSurprised.FREQUENCY_SECONDS:
+            key = NabSurprised.RARELY
+        return random.uniform(0, NabSurprised.FREQUENCY_SECONDS[key])
 
     async def process_nabd_packet(self, packet):
         if packet["type"] == "asr_event":

--- a/nabsurprised/templates/nabsurprised/settings.html
+++ b/nabsurprised/templates/nabsurprised/settings.html
@@ -10,10 +10,11 @@
         <label for="surpriseSelect" class="col-6 col-form-label">{% trans "Surprise Frequency" %}</label>
         <div class="col-6">
           <select name="surprise_frequency" id="surpriseSelect">
+            <option value="30"{% if config.surprise_frequency == 30 %} selected{% endif %}>{% trans "Rarely" context "Surprise frequency" %}</option>
             <option value="50"{% if config.surprise_frequency == 50 %} selected{% endif %}>{% trans "Sometimes" context "Surprise frequency" %}</option>
             <option value="125"{% if config.surprise_frequency == 125 %} selected{% endif %}>{% trans "Often" context "Surprise frequency" %}</option>
             <option value="250"{% if config.surprise_frequency == 250 %} selected{% endif %}>{% trans "Very often" context "Surprise frequency" %}</option>
-            <option value="0"{% if config.surprise_frequency == 0 %} selected{% endif %}>{% trans "Disabled" context "Surprise frequency" %}</option>
+            <option value="0"{% if config.surprise_frequency == 0 %} selected{% endif %}>{% trans "Never" context "Surprise frequency" %}</option>
           </select>
         </div>
       </div>


### PR DESCRIPTION
Resolves #128.
`nabsurprised` frequency computation changed to try and match original Violet frequency scale (see https://github.com/nabaztag2018/pynab/issues/128#issuecomment-597740918).
