### PR TITLE
Docker Dockerfile: remove (unneeded) snips-nlu packages from requirements

### DIFF
--- a/.github/workflows/arm-runner.yml
+++ b/.github/workflows/arm-runner.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        base_image: ['raspios_lite:2021-05-07', 'dietpi:rpi_armv6_buster']
+        base_image: ['raspios_lite:2021-05-07']
 
     steps:
       - name: Checkout pynab
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        base_image: ['raspios_lite:2021-05-07', 'dietpi:rpi_armv6_buster']
+        base_image: ['raspios_lite:2021-05-07']
     if: github.ref == 'refs/heads/releng' || startsWith(github.ref, 'refs/tags/')
 
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        base_image: ['raspios_lite:2021-05-07', 'dietpi:rpi_armv6_buster']
+        base_image: ['raspios_lite:2021-05-07']
     if: ${{ needs.check_date.outputs.SHOULD_RUN == 'true' }}
 
     steps:
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        base_image: ['raspios_lite:2021-05-07', 'dietpi:rpi_armv6_buster']
+        base_image: ['raspios_lite:2021-05-07']
     if: ${{ needs.check_date.outputs.SHOULD_RUN == 'true' }}
 
     steps:

--- a/Docker/nab/Dockerfile
+++ b/Docker/nab/Dockerfile
@@ -40,7 +40,7 @@ RUN python3.7 -m venv ${VIRTUAL_ENV}
 ENV PATH=${VIRTUAL_ENV}/bin:${PATH}
 
 COPY requirements.txt /tmp/requirements.txt
-RUN grep -vE py-kaldi-asr < /tmp/requirements.txt > /tmp/requirements_docker.txt
+RUN grep -v -e py-kaldi-asr -e snips-nlu < /tmp/requirements.txt > /tmp/requirements_docker.txt
 RUN ${VIRTUAL_ENV}/bin/pip install -r /tmp/requirements_docker.txt
 
 ENV NABD_HOST=pynab

--- a/Docker/nab/requirements.txt
+++ b/Docker/nab/requirements.txt
@@ -1,7 +1,7 @@
 # Direct dependencies & pre-built binaries
 wheel
 black==21.4b2
-Django==3.1.12
+Django==3.1.14
 flake8==3.9.1
 gunicorn==20.0.4
 isort==5.8.0
@@ -51,7 +51,7 @@ importlib-metadata==1.3.0
 joblib==0.14.1
 more-itertools==8.0.2
 num2words==0.5.10
-numpy==1.20.2
+numpy==1.21.0
 packaging==19.2
 pathspec==0.8.1
 plac==1.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Direct dependencies & pre-built binaries
 wheel
 black==21.4b2
-Django==3.1.12
+Django==3.1.14
 flake8==3.9.1
 gunicorn==20.0.4
 isort==5.8.0
@@ -51,7 +51,7 @@ importlib-metadata==1.3.0
 joblib==0.14.1
 more-itertools==8.0.2
 num2words==0.5.10
-numpy==1.20.2
+numpy==1.21.0
 packaging==19.2
 pathspec==0.8.1
 plac==1.1.3


### PR DESCRIPTION
In Docker environment, remove from requirements (as was already done for `kaldi-asr`) the `snips-nlu` packages (which are not used in Docker environment anyway).
This allows Docker environment to build/run on host architectures, such as aarch64 (Apple M1 machines), for which pre-compiled snips-nlu packages are not present on PyPi.