### PR TITLE
Do not generate zero2 images

### DIFF
--- a/.github/workflows/arm-runner.yml
+++ b/.github/workflows/arm-runner.yml
@@ -8,8 +8,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-#        target: [zero_raspbian, zero_raspios, zero_dietpi, zero2_raspios, zero2_dietpi, zero2_64_raspios, zero2_64_dietpi]
-        target: [zero_raspbian, zero_raspios, zero_dietpi, zero2_raspios, zero2_dietpi]
+##        target: [zero_raspbian, zero_raspios, zero_dietpi, zero2_raspios, zero2_dietpi, zero2_64_raspios, zero2_64_dietpi]
+#        target: [zero_raspbian, zero_raspios, zero_dietpi, zero2_raspios, zero2_dietpi]
+        target: [zero_raspbian, zero_raspios, zero_dietpi]
         include:
         - target: zero_raspbian
           cpu: arm1176
@@ -23,22 +24,22 @@ jobs:
           cpu: arm1176
           cpu_info: cpuinfo/raspberrypi_zero_w
           base_image: dietpi:rpi_armv6_bullseye
-        - target: zero2_raspios
-          cpu: cortex-a7
-          cpu_info: cpuinfo/raspberrypi_zero2_w
-          base_image: raspios_lite:latest
-        - target: zero2_dietpi
-          cpu: cortex-a7
-          cpu_info: cpuinfo/raspberrypi_zero2_w
-          base_image: dietpi:rpi_armv7_bullseye
-#        - target: zero2_64_raspios
-#          cpu: cortex-a53
-#          cpu_info: cpuinfo/raspberrypi_zero2_w_arm64
-#          base_image: raspios_lite_arm64:latest
-#        - target: zero2_64_dietpi
-#          cpu: cortex-a53
-#          cpu_info: cpuinfo/raspberrypi_zero2_w_arm64
-#          base_image: dietpi:rpi_armv8_bullseye
+#        - target: zero2_raspios
+#          cpu: cortex-a7
+#          cpu_info: cpuinfo/raspberrypi_zero2_w
+#          base_image: raspios_lite:latest
+#        - target: zero2_dietpi
+#          cpu: cortex-a7
+#          cpu_info: cpuinfo/raspberrypi_zero2_w
+#          base_image: dietpi:rpi_armv7_bullseye
+##        - target: zero2_64_raspios
+##          cpu: cortex-a53
+##          cpu_info: cpuinfo/raspberrypi_zero2_w_arm64
+##          base_image: raspios_lite_arm64:latest
+##        - target: zero2_64_dietpi
+##          cpu: cortex-a53
+##          cpu_info: cpuinfo/raspberrypi_zero2_w_arm64
+##          base_image: dietpi:rpi_armv8_bullseye
     steps:
       - name: Checkout pynab
         uses: actions/checkout@v2
@@ -73,8 +74,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-#        target: [zero_raspbian, zero_raspios, zero_dietpi, zero2_raspios, zero2_dietpi, zero2_64_raspios, zero2_64_dietpi]
-        target: [zero_raspbian, zero_raspios, zero_dietpi, zero2_raspios, zero2_dietpi]
+##        target: [zero_raspbian, zero_raspios, zero_dietpi, zero2_raspios, zero2_dietpi, zero2_64_raspios, zero2_64_dietpi]
+#        target: [zero_raspbian, zero_raspios, zero_dietpi, zero2_raspios, zero2_dietpi]
+        target: [zero_raspbian, zero_raspios, zero_dietpi]
         include:
         - target: zero_raspbian
           cpu: arm1176
@@ -88,22 +90,22 @@ jobs:
           cpu: arm1176
           cpu_info: cpuinfo/raspberrypi_zero_w
           base_image: dietpi:rpi_armv6_bullseye
-        - target: zero2_raspios
-          cpu: cortex-a7
-          cpu_info: cpuinfo/raspberrypi_zero2_w
-          base_image: raspios_lite:latest
-        - target: zero2_dietpi
-          cpu: cortex-a7
-          cpu_info: cpuinfo/raspberrypi_zero2_w
-          base_image: dietpi:rpi_armv7_bullseye
-#        - target: zero2_64_raspios
-#          cpu: cortex-a53
-#          cpu_info: cpuinfo/raspberrypi_zero2_w_arm64
-#          base_image: raspios_lite_arm64:latest
-#        - target: zero2_64_dietpi
-#          cpu: cortex-a53
-#          cpu_info: cpuinfo/raspberrypi_zero2_w_arm64
-#          base_image: dietpi:rpi_armv8_bullseye
+#        - target: zero2_raspios
+#          cpu: cortex-a7
+#          cpu_info: cpuinfo/raspberrypi_zero2_w
+#          base_image: raspios_lite:latest
+#        - target: zero2_dietpi
+#          cpu: cortex-a7
+#          cpu_info: cpuinfo/raspberrypi_zero2_w
+#          base_image: dietpi:rpi_armv7_bullseye
+##        - target: zero2_64_raspios
+##          cpu: cortex-a53
+##          cpu_info: cpuinfo/raspberrypi_zero2_w_arm64
+##          base_image: raspios_lite_arm64:latest
+##        - target: zero2_64_dietpi
+##          cpu: cortex-a53
+##          cpu_info: cpuinfo/raspberrypi_zero2_w_arm64
+##          base_image: dietpi:rpi_armv8_bullseye
     steps:
       - name: Checkout pynab
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,7 @@ jobs:
           sudo apt update -y
           sudo apt-get install -y libasound2-dev libmpg123-dev libatlas-base-dev curl
           wget -q -O - "https://github.com/pguyot/kaldi/releases/download/v5.4.1/kaldi-c3260f2-linux_x86_64-vfp.tar.xz" | sudo tar xJ -C /
+          #wget -q -O - "https://github.com/pguyot/kaldi/releases/download/e4940d045/kaldi-e4940d045-linux_ubuntu20.04-x86_64.tar.xz" | sudo tar xJ -C /
           sudo ldconfig
           python -m pip install --upgrade pip
           pip install cython numpy setuptools_rust wheel


### PR DESCRIPTION
Sequel to PR #305:
- Build only **zero** images in GitHub workflows (see https://github.com/nabaztag2018/pynab/issues/316#issuecomment-1059739140).