### PR TITLE
Cleanup services startup

### DIFF
--- a/nabclockd/nabclockd.py
+++ b/nabclockd/nabclockd.py
@@ -52,11 +52,12 @@ class NabClockd(nabservice.NabService):
         synchronized_date = subprocess.run(
             ["stat", "-c", "%y", "/run/systemd/timesync/synchronized"],
             stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
         ).stdout
         if synchronized_date > self.__boot_date:
             self.__synchronized_since_boot = True
             if not first_run:
-                logging.debug("Clock has been synchronized")
+                logging.info("Clock has been synchronized")
             return True
         if first_run:
             logging.warning(

--- a/nabd/nabd.service
+++ b/nabd/nabd.service
@@ -10,6 +10,7 @@ RestartSec=1
 User=root
 WorkingDirectory=/home/pi/pynab
 EnvironmentFile=/home/pi/pynab/nabd/nabd.conf
+ExecStartPre=sh -c 'until /usr/bin/pg_isready; do sleep 1; done'
 ExecStart=/home/pi/pynab/venv/bin/python -m nabd.nabd
 PIDFile=/run/nabd.pid
 


### PR DESCRIPTION
- nabd: make sure PostgreSQL DB is ready before starting service
This avoids possible restarts of `nab*d` services (and associated log pollution) on boot.
- nabclockd: cleanup date synchronisation check,
and log "Clock has been synchronized" message as `INFO` (rather than `DEBUG`)
So that message always appears if there was a previous `WARNING` message stating clock was not synchronised.