### PR TITLE
Install Pynab (and drivers) in /opt directory

### DIFF
--- a/.github/workflows/arm-runner.yml
+++ b/.github/workflows/arm-runner.yml
@@ -51,20 +51,20 @@ jobs:
           base_image: ${{ matrix.base_image }}
           cpu: ${{ matrix.cpu }}
           cpu_info: ${{ matrix.cpu_info }}
-          copy_repository_path: /home/pi/pynab
+          copy_repository_path: /opt/pynab
           optimize_image: no
           commands: |
             sudo useradd pi || true
             sudo sh -c "[ ! -f /etc/sudoers.d/010_pi-nopasswd ] && usermod -aG sudo pi && echo 'pi ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/010_pi-nopasswd || true"
-            sudo chown -hR pi:pi /home/pi/pynab
+            sudo chown -hR pi:pi /opt/pynab
             sudo apt-get update -y --allow-releaseinfo-change
             sudo apt-get install --no-install-recommends -y postgresql libpq-dev git python3 python3-venv python3-dev gettext nginx openssl libssl-dev libffi-dev libmpg123-dev libasound2-dev libatlas-base-dev libgfortran5 libopenblas-dev liblapack-dev zram-tools
             sudo mkdir -p /run/systemd/timesync/ && sudo touch /run/systemd/timesync/synchronized
             sudo apt-get install --no-install-recommends -y alsa-utils xz-utils avahi-daemon
             if [ `uname -m` = 'armv6l' -o `uname -m` = 'armv7l' ]; then
-                sudo -u pi taskset -c 0 /bin/bash install.sh ci-chroot-test
+                sudo -u pi taskset -c 0 /bin/bash /opt/pynab/install.sh ci-chroot-test
             else
-                sudo -u pi /bin/bash install.sh ci-chroot-test
+                sudo -u pi /bin/bash /opt/pynab/install.sh ci-chroot-test
             fi
   create_image:
     name: Build image
@@ -141,18 +141,18 @@ jobs:
           cpu: ${{ matrix.cpu }}
           cpu_info: ${{ matrix.cpu_info }}
           optimize_image: yes
-          copy_repository_path: /home/pi/pynab
+          copy_repository_path: /opt/pynab
           commands: |
             sudo apt-get update -y --allow-releaseinfo-change
             echo GITHUB_BRANCH=${{ steps.image_and_branch_name.outputs.LOCAL_BRANCH }}
             echo GITHUB_REPOSITORY=${{ github.repository }}
             cd /tmp
-            sudo cp -p /home/pi/pynab/setup /tmp/setup
+            sudo cp -p /opt/pynab/setup /tmp/setup
             if [ ${{ steps.image_and_branch_name.outputs.CLONE_RELEASE }} = "yes" ]; then
-                sudo rm -rf /home/pi/pynab
+                sudo rm -rf /opt/pynab
             else
-                sudo useradd pi || true
-                sudo chown -hR pi:pi /home/pi/pynab
+                sudo useradd tagtagtag -u 1000 -g 1000 -m || true
+                sudo chown -hR 1000:1000 /opt/pynab
             fi
             if [ `uname -m` = 'armv6l' -o `uname -m` = 'armv7l' ]; then
                 sudo GITHUB_BRANCH=${{ steps.image_and_branch_name.outputs.LOCAL_BRANCH }} GITHUB_REPOSITORY=${{ github.repository }} taskset -c 0 /bin/bash /tmp/setup ci-chroot

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ use editors with SFTP support.
 If you haven't done so yet, fork the repository on GitHub, then add this fork
 to your rabbit's repository.
 ```
-cd $HOME/pynab
+cd /opt/pynab
 git remote add fork https://github.com/YOUR_GITHUB_USERNAME/pynab.git
 ```
 

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -58,7 +58,7 @@ without having to modify Pynab which assumes socket-based DB communication.
 ### Host volume
 
 The pynab project directory is shared via a host volume, mounted in
-`/home/pi/pynab` inside the containers to replicate the Raspberry Pi location.
+`/opt/pynab` inside the containers to replicate the Raspberry Pi location.
 
 ### Synchronization between containers
 

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -21,7 +21,7 @@ services:
             context: nab/
             dockerfile: Dockerfile
         volumes:
-          - ../:/home/pi/pynab
+          - ../:/opt/pynab
           - var-run-postgresql:/var/run/postgresql
         depends_on:
           - db

--- a/Docker/nab/Dockerfile
+++ b/Docker/nab/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
 COPY *.sh /usr/local/bin/
 
 # Fake nabd systemd service file used to retrieve the working directory
-RUN echo "WorkingDirectory=/home/pi/pynab" > /lib/systemd/system/nabd.service
+RUN echo "WorkingDirectory=/opt/pynab" > /lib/systemd/system/nabd.service
 
 # Fake systemd-time-wait-sync.service needed by nabclockd
 RUN mkdir -p /run/systemd/timesync/ && touch /run/systemd/timesync/synchronized
@@ -27,15 +27,17 @@ RUN ln -fs /usr/share/zoneinfo/Europe/Paris /etc/localtime
 RUN /bin/echo -e "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf
 
 RUN groupadd -g 1000 pi
-RUN useradd -u 1000 -m pi -g pi -s /bin/bash
-RUN echo "pi ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/010_pi-nopasswd
+RUN useradd -u 1000 -g pi -m -s /bin/bash tagtagtag
+RUN echo "tagtagtag ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/010_tagtagtag-nopasswd
 
-USER pi
+RUN mkdir -p /opt/pynab /opt/venv
+RUN chown tagtagtag:pi /opt/pynab /opt/venv
 
-RUN mkdir -p /home/pi/pynab
-WORKDIR /home/pi/pynab
+USER tagtagtag
 
-ENV VIRTUAL_ENV=/home/pi/venv
+WORKDIR /opt/pynab
+
+ENV VIRTUAL_ENV=/opt/venv
 RUN python3.7 -m venv ${VIRTUAL_ENV}
 ENV PATH=${VIRTUAL_ENV}/bin:${PATH}
 

--- a/Docker/nab/run-inits.sh
+++ b/Docker/nab/run-inits.sh
@@ -14,8 +14,8 @@ if [ ! ${RC} -eq 0 ]; then
 fi
 
 echo "${SELF}: running DB model migrations..."
-/home/pi/venv/bin/python3 /home/pi/pynab/manage.py migrate
+/opt/venv/bin/python3 /opt/pynab/manage.py migrate
 
 echo "${SELF}: updating localization messages..."
 all_locales="-l fr_FR -l de_DE -l en_US -l en_GB -l it_IT -l es_ES -l ja_jp -l pt_BR -l de -l en -l es -l fr -l it -l ja -l pt"
-/home/pi/venv/bin/python3 /home/pi/pynab/manage.py compilemessages ${all_locales}
+/opt/venv/bin/python3 /opt/pynab/manage.py compilemessages ${all_locales}

--- a/Docker/nab/run-service.sh
+++ b/Docker/nab/run-service.sh
@@ -12,6 +12,6 @@ fi
 ln -sf /dev/stdout /var/log/${SERVICE}.log
 while :
 do
-    /home/pi/venv/bin/python3 -m ${SERVICE}.${SERVICE} &
+    /opt/venv/bin/python3 -m ${SERVICE}.${SERVICE} &
     wait $!
 done

--- a/Docker/nab/run-webserver.sh
+++ b/Docker/nab/run-webserver.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-exec /home/pi/venv/bin/gunicorn --timeout 60 -b 0.0.0.0 nabweb.wsgi
+exec /opt/venv/bin/gunicorn --timeout 60 -b 0.0.0.0 nabweb.wsgi

--- a/nab8balld/nab8balld.service
+++ b/nab8balld/nab8balld.service
@@ -8,9 +8,9 @@ Type=simple
 Restart=always
 RestartSec=1
 User=root
-WorkingDirectory=/home/pi/pynab
-EnvironmentFile=/home/pi/pynab/nab8balld/nab8balld.conf
-ExecStart=/home/pi/pynab/venv/bin/python -m nab8balld.nab8balld
+WorkingDirectory=/opt/pynab
+EnvironmentFile=/opt/pynab/nab8balld/nab8balld.conf
+ExecStart=/opt/pynab/venv/bin/python -m nab8balld.nab8balld
 PIDFile=/run/nab8balld.pid
 
 [Install]

--- a/nabairqualityd/nabairqualityd.service
+++ b/nabairqualityd/nabairqualityd.service
@@ -8,9 +8,9 @@ Type=simple
 Restart=always
 RestartSec=1
 User=root
-WorkingDirectory=/home/pi/pynab
-EnvironmentFile=/home/pi/pynab/nabairqualityd/nabairqualityd.conf
-ExecStart=/home/pi/pynab/venv/bin/python -m nabairqualityd.nabairqualityd
+WorkingDirectory=/opt/pynab
+EnvironmentFile=/opt/pynab/nabairqualityd/nabairqualityd.conf
+ExecStart=/opt/pynab/venv/bin/python -m nabairqualityd.nabairqualityd
 PIDFile=/run/nabairqualityd.pid
 
 [Install]

--- a/nabbookd/nabbookd.service
+++ b/nabbookd/nabbookd.service
@@ -8,9 +8,9 @@ Type=simple
 Restart=always
 RestartSec=1
 User=root
-WorkingDirectory=/home/pi/pynab
-EnvironmentFile=/home/pi/pynab/nabbookd/nabbookd.conf
-ExecStart=/home/pi/pynab/venv/bin/python -m nabbookd.nabbookd
+WorkingDirectory=/opt/pynab
+EnvironmentFile=/opt/pynab/nabbookd/nabbookd.conf
+ExecStart=/opt/pynab/venv/bin/python -m nabbookd.nabbookd
 PIDFile=/run/nabbookd.pid
 
 [Install]

--- a/nabboot/nabboot.py
+++ b/nabboot/nabboot.py
@@ -1,4 +1,4 @@
-#!/home/pi/pynab/venv/bin/python
+#!/opt/pynab/venv/bin/python
 
 # Script executed at boot and at shutdown.
 # At boot, set leds to orange.

--- a/nabboot/nabboot.service
+++ b/nabboot/nabboot.service
@@ -4,8 +4,8 @@ Description=Nabaztag boot script, initializing leds and motors
 [Service]
 Type=oneshot
 User=root
-WorkingDirectory=/home/pi/pynab
-ExecStart=/home/pi/pynab/venv/bin/python -m nabboot.nabboot start
+WorkingDirectory=/opt/pynab
+ExecStart=/opt/pynab/venv/bin/python -m nabboot.nabboot start
 
 [Install]
 WantedBy=multi-user.target

--- a/nabclockd/nabclockd.service
+++ b/nabclockd/nabclockd.service
@@ -8,9 +8,9 @@ Type=simple
 Restart=always
 RestartSec=1
 User=root
-WorkingDirectory=/home/pi/pynab
-EnvironmentFile=/home/pi/pynab/nabclockd/nabclockd.conf
-ExecStart=/home/pi/pynab/venv/bin/python -m nabclockd.nabclockd
+WorkingDirectory=/opt/pynab
+EnvironmentFile=/opt/pynab/nabclockd/nabclockd.conf
+ExecStart=/opt/pynab/venv/bin/python -m nabclockd.nabclockd
 PIDFile=/run/nabclockd.pid
 
 [Install]

--- a/nabd/nabd.service
+++ b/nabd/nabd.service
@@ -8,10 +8,10 @@ Type=simple
 Restart=always
 RestartSec=1
 User=root
-WorkingDirectory=/home/pi/pynab
-EnvironmentFile=/home/pi/pynab/nabd/nabd.conf
+WorkingDirectory=/opt/pynab
+EnvironmentFile=/opt/pynab/nabd/nabd.conf
 ExecStartPre=sh -c 'until /usr/bin/pg_isready; do sleep 1; done'
-ExecStart=/home/pi/pynab/venv/bin/python -m nabd.nabd
+ExecStart=/opt/pynab/venv/bin/python -m nabd.nabd
 PIDFile=/run/nabd.pid
 
 [Install]

--- a/nabiftttd/nabiftttd.conf
+++ b/nabiftttd/nabiftttd.conf
@@ -1,1 +1,1 @@
-LOGLEVEL=INFO
+../nabd/nabd.conf

--- a/nabiftttd/nabiftttd.service
+++ b/nabiftttd/nabiftttd.service
@@ -8,9 +8,9 @@ Type=simple
 Restart=always
 RestartSec=1
 User=root
-WorkingDirectory=/home/pi/pynab
-EnvironmentFile=/home/pi/pynab/nabiftttd/nabiftttd.conf
-ExecStart=/home/pi/pynab/venv/bin/python -m nabiftttd.nabiftttd
+WorkingDirectory=/opt/pynab
+EnvironmentFile=/opt/pynab/nabiftttd/nabiftttd.conf
+ExecStart=/opt/pynab/venv/bin/python -m nabiftttd.nabiftttd
 PIDFile=/run/nabiftttd.pid
 
 [Install]

--- a/nabmastodond/nabmastodond.service
+++ b/nabmastodond/nabmastodond.service
@@ -8,9 +8,9 @@ Type=simple
 Restart=always
 RestartSec=1
 User=root
-WorkingDirectory=/home/pi/pynab
-EnvironmentFile=/home/pi/pynab/nabmastodond/nabmastodond.conf
-ExecStart=/home/pi/pynab/venv/bin/python -m nabmastodond.nabmastodond
+WorkingDirectory=/opt/pynab
+EnvironmentFile=/opt/pynab/nabmastodond/nabmastodond.conf
+ExecStart=/opt/pynab/venv/bin/python -m nabmastodond.nabmastodond
 PIDFile=/run/nabmastodond.pid
 
 [Install]

--- a/nabsurprised/nabsurprised.service
+++ b/nabsurprised/nabsurprised.service
@@ -8,9 +8,9 @@ Type=simple
 Restart=always
 RestartSec=1
 User=root
-WorkingDirectory=/home/pi/pynab
-EnvironmentFile=/home/pi/pynab/nabsurprised/nabsurprised.conf
-ExecStart=/home/pi/pynab/venv/bin/python -m nabsurprised.nabsurprised
+WorkingDirectory=/opt/pynab
+EnvironmentFile=/opt/pynab/nabsurprised/nabsurprised.conf
+ExecStart=/opt/pynab/venv/bin/python -m nabsurprised.nabsurprised
 PIDFile=/run/nabsurprised.pid
 
 [Install]

--- a/nabtaichid/nabtaichid.service
+++ b/nabtaichid/nabtaichid.service
@@ -8,9 +8,9 @@ Type=simple
 Restart=always
 RestartSec=1
 User=root
-WorkingDirectory=/home/pi/pynab
-EnvironmentFile=/home/pi/pynab/nabtaichid/nabtaichid.conf
-ExecStart=/home/pi/pynab/venv/bin/python -m nabtaichid.nabtaichid
+WorkingDirectory=/opt/pynab
+EnvironmentFile=/opt/pynab/nabtaichid/nabtaichid.conf
+ExecStart=/opt/pynab/venv/bin/python -m nabtaichid.nabtaichid
 PIDFile=/run/nabtaichid.pid
 
 [Install]

--- a/nabweatherd/nabweatherd.service
+++ b/nabweatherd/nabweatherd.service
@@ -8,9 +8,9 @@ Type=simple
 Restart=always
 RestartSec=1
 User=root
-WorkingDirectory=/home/pi/pynab
-EnvironmentFile=/home/pi/pynab/nabweatherd/nabweatherd.conf
-ExecStart=/home/pi/pynab/venv/bin/python -m nabweatherd.nabweatherd
+WorkingDirectory=/opt/pynab
+EnvironmentFile=/opt/pynab/nabweatherd/nabweatherd.conf
+ExecStart=/opt/pynab/venv/bin/python -m nabweatherd.nabweatherd
 PIDFile=/run/nabweatherd.pid
 
 [Install]

--- a/nabweb/nabweb-boot.service
+++ b/nabweb/nabweb-boot.service
@@ -5,7 +5,7 @@ Before=nginx.service
 [Service]
 Type=oneshot
 User=root
-WorkingDirectory=/home/pi/pynab
+WorkingDirectory=/opt/pynab
 ExecStart=mkdir -p /var/log/nginx
 
 [Install]

--- a/nabweb/nabweb.service
+++ b/nabweb/nabweb.service
@@ -8,8 +8,8 @@ Type=simple
 Restart=always
 RestartSec=1
 User=root
-WorkingDirectory=/home/pi/pynab
-ExecStart=/home/pi/pynab/venv/bin/gunicorn --timeout 60 nabweb.wsgi
+WorkingDirectory=/opt/pynab
+ExecStart=/opt/pynab/venv/bin/gunicorn --timeout 60 nabweb.wsgi
 
 [Install]
 WantedBy=multi-user.target

--- a/nabweb/nginx-site.conf
+++ b/nabweb/nginx-site.conf
@@ -11,10 +11,10 @@ server {
   keepalive_timeout 5;
 
   location /static/nabweb/ {
-    root /home/pi/pynab/nabweb;
+    root /opt/pynab/nabweb;
   }
   location /static/nabbookd/ {
-    root /home/pi/pynab/nabbookd;
+    root /opt/pynab/nabbookd;
   }
   location / {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/setup
+++ b/setup
@@ -4,7 +4,7 @@ shopt -s extglob
 trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 IFS=$'\n\t'
 
-# Source for this script:
+# Original source for this script:
 # https://github.com/kr15h/travis-raspbian-image
 # https://disconnected.systems/blog/custom-rpi-image-with-github-travis/
 
@@ -31,17 +31,20 @@ LC_ALL=C
 if [ -d "/boot/dietpi" ]
 then
     # DietPi distro
-    owner=dietpi
-    home_dir=/home/${owner}
+    distro="dietpi"
 elif [ -f "/etc/rpi-issue" ]
 then
     # Raspberry Pi OS distro
-    owner=pi
-    home_dir=/home/${owner}
+    distro="raspios"
 else
     echo "$(basename ${0}): unsupported Linux distribution!"
     exit 3
 fi
+
+owner=$(getent passwd 1000 | cut -d: -f1)
+group=$(getent passwd 1000 | cut -d: -f4)
+home_dir=$(getent passwd 1000 | cut -d: -f6)
+inst_dir="/opt"
 
 if [ "${1:-}" == "ci-chroot" ]
 then
@@ -58,6 +61,7 @@ then
         exit 1
     fi
     rm -rf ${home_dir}/pynab ${home_dir}/wm8960 ${home_dir}/tagtagtag-ears ${home_dir}/cr14 ${home_dir}/st25r391x
+    rm -rf ${inst_dir}/pynab ${inst_dir}/wm8960 ${inst_dir}/tagtagtag-ears ${inst_dir}/cr14 ${inst_dir}/st25r391x
 else
     echo "Usage: $(basename ${0}) pi-zero|ci-chroot"
     exit 2
@@ -118,12 +122,14 @@ then
     echo "web_service: nginx.service" >> /etc/comitup.conf
     echo "ap_name: Nabaztag-<nnn>" >> /etc/comitup.conf
     echo "service_name: Nabaztag" >> /etc/comitup.conf
-	echo "external_callback: /home/pi/pynab/comitup-callback.sh" >> /etc/comitup.conf
+    echo "external_callback: /opt/pynab/comitup-callback.sh" >> /etc/comitup.conf
 
-    if [ -f "/boot/dietpi.txt" ]
+    if [ "${distro}" == "raspios"  ]
     then
-        # DietPi distro
-        hostname="DietPi"
+        # assume user will do any needed SD card configuration.
+        :
+    elif [ "${distro}" == "dietpi" ]
+    then
         echo "Setting DietPi 'first boot' parameters."
         sed -i "s/\(AUTO_SETUP_KEYBOARD_LAYOUT\)=.*/\1=fr/" /boot/dietpi.txt
         sed -i "s/\(AUTO_SETUP_TIMEZONE\)=.*/\1=Europe\/Paris/" /boot/dietpi.txt
@@ -136,13 +142,10 @@ then
         # -4=Daemon + Drift rather than 2=boot + daily (DietPi default):
         sed -i "s/\(CONFIG_NTP_MODE\)=.*/\1=4/" /boot/dietpi.txt
         sed -i "s/\(CONFIG_SERIAL_CONSOLE_ENABLE\)=.*/\1=0/" /boot/dietpi.txt
-        rm /boot/dietpi-wifi.txt
-    else
-        # Raspberry Pi OS distro
-        hostname="raspberrypi"
     fi
 
     echo "Setting hostname."
+    hostname=$(cat /etc/hostname | tr -d " \t\n\r")
     sed -i "s/${hostname}/Nabaztag/" /etc/hostname
     sed -i "s/${hostname}/Nabaztag/" /etc/hosts
 
@@ -151,31 +154,14 @@ then
     ln -fs /usr/share/zoneinfo/Europe/Paris /etc/localtime
 fi
 
-if ! grep -q "^${owner}:" /etc/passwd
-then
-    echo "Creating user ${owner} with home directory ${home_dir}."
-    useradd -d ${home_dir} -m ${owner}
-    echo "${owner} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/010_${owner}-nopasswd
-fi
 echo "Ensuring user ${owner} has appropriate sudo privileges."
 usermod -aG sudo ${owner}
-
-if [ "${owner}" == "dietpi" ]
+if [ "${distro}" == "raspios"  ]
 then
-    # patch for DietPi, to allow sudo -u: ALL=(ALL) needed:
+    echo "${owner} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/010_${owner}-nopasswd
+elif [ "${distro}" == "dietpi" ]
+then
     echo "${owner} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/${owner}
-
-    # patch for DietPi, to cleanup leftover pi "user" used when building image,
-    # after taking over existing local Pynab repository, if any:
-    pi_user="pi"
-    if [ ! -d ${home_dir}/pynab -a -d /home/${pi_user}/pynab ]
-    then
-	echo "Moving /home/${pi_user}/pynab to ${home_dir}/pynab."
-	mv /home/${pi_user}/pynab ${home_dir}/pynab
-	chown -hR ${owner}:${owner} ${home_dir}/pynab
-    fi
-    userdel -r ${pi_user} 2>/dev/null || true
-    rmdir /home/${pi_user} 2>/dev/null || true
 fi
 
 echo "Installing required packages."
@@ -195,43 +181,48 @@ build_and_install_driver() {
 }
 
 echo "Installing sound driver for Ulule 2019 cards."
-cd ${home_dir}
-sudo -u ${owner} git clone --depth 1 -b tagtagtag-sound https://github.com/pguyot/wm8960
-cd ${home_dir}/wm8960
+sudo mkdir -p ${inst_dir}/wm8960
+sudo chown ${owner}:${group} ${inst_dir}/wm8960
+sudo -u ${owner} git clone --depth 1 -b tagtagtag-sound https://github.com/pguyot/wm8960 ${inst_dir}/wm8960
+cd ${inst_dir}/wm8960
 build_and_install_driver
 
 echo "Installing ears driver."
-cd ${home_dir}
-sudo -u ${owner} git clone --depth 1 -b ${driver_branch} https://github.com/pguyot/tagtagtag-ears
-cd ${home_dir}/tagtagtag-ears
+sudo mkdir -p ${inst_dir}/tagtagtag-ears
+sudo chown ${owner}:${group} ${inst_dir}/tagtagtag-ears
+sudo -u ${owner} git clone --depth 1 -b ${driver_branch} https://github.com/pguyot/tagtagtag-ears ${inst_dir}/tagtagtag-ears
+cd ${inst_dir}/tagtagtag-ears
 build_and_install_driver
 
 echo "Installing RFID reader driver for TAGTAG."
-cd ${home_dir}
-sudo -u ${owner} git clone --depth 1 -b ${driver_branch} https://github.com/pguyot/cr14
-cd ${home_dir}/cr14
+sudo mkdir -p ${inst_dir}/cr14
+sudo chown ${owner}:${group} ${inst_dir}/cr14
+sudo -u ${owner} git clone --depth 1 -b ${driver_branch} https://github.com/pguyot/cr14 ${inst_dir}/cr14
+cd ${inst_dir}/cr14
 build_and_install_driver
 
 echo "Installing RFID reader driver for 2022 NFC card."
-cd ${home_dir}
-sudo -u ${owner} git clone --depth 1 -b ${st25_branch} https://github.com/pguyot/st25r391x
-cd ${home_dir}/st25r391x
+sudo mkdir -p ${inst_dir}/st25r391x
+sudo chown ${owner}:${group} ${inst_dir}/st25r391x
+sudo -u ${owner} git clone --depth 1 -b ${st25_branch} https://github.com/pguyot/st25r391x ${inst_dir}/st25r391x
+cd ${inst_dir}/st25r391x
 build_and_install_driver
 
-cd ${home_dir}
-if [ -d "pynab" ]
+if [ -d "${inst_dir}/pynab" ]
 then
     echo "Using existing local Pynab repository."
 else
     echo "Cloning Pynab ${pynab_branch} branch from ${pynab_repository}."
-    sudo -u ${owner} git clone --depth 1 -b ${pynab_branch} https://github.com/${pynab_repository}.git
+    sudo mkdir -p ${inst_dir}/pynab
+    sudo chown ${owner}:${group} ${inst_dir}/pynab
+    sudo -u ${owner} git clone --depth 1 -b ${pynab_branch} https://github.com/${pynab_repository}.git ${inst_dir}/pynab
 fi
 
 echo "Installing NabBlockly."
 sudo apt-get install --no-install-recommends -y erlang-base erlang-dev erlang-inets erlang-tools erlang-xmerl
-cd ${home_dir}/pynab
+cd ${inst_dir}/pynab
 sudo -u ${owner} git clone --depth 1 -b ${driver_branch} https://github.com/pguyot/nabblockly
-cd nabblockly
+cd ${inst_dir}/pynab/nabblockly
 # Until we can get OTP 24 from Raspian or Erlang Solutions, get an older rebar binary
 sudo -u ${owner} wget https://github.com/erlang/rebar3/releases/download/3.15.1/rebar3 && chmod +x rebar3
 sudo apt-get install --no-install-recommends -y g++
@@ -239,7 +230,7 @@ sudo -u ${owner} ./rebar3 release
 
 echo "Running Pynab install script."
 sudo apt-get install --no-install-recommends -y alsa-utils xz-utils avahi-daemon
-cd ${home_dir}/pynab
+cd ${inst_dir}/pynab
 sudo -u ${owner} /bin/bash install.sh ${install_env}
 
 echo "Cleaning up."


### PR DESCRIPTION
`/home/pi` is no more a safe place for install on Raspberry Pi OS, since `pi` user  (default user with `uid:gid=1000:1000`) may be changed (renamed - and its home directory renamed accordingly) when setting up the flashed SD card. See:
- https://downloads.raspberrypi.org/raspios_lite_armhf/release_notes.txt  (_2022-04-04_ entry)
- https://www.raspberrypi.com/news/raspberry-pi-bullseye-update-april-2022/

This PR changes the install location for pynab (and drivers) to `/opt`, as was already done for Kaldi. The Git repositories still belong to user with `uid=1000`.
**Note**: this change applies to new Pynab images (setup process), but is backward compatible with existing Pynab installations: the Pynab (and drivers) upgrade/install process still transparently handles existing install locations (`/home/pi `or other locations).

This change also makes the Pynab RasPiOS and DietPi images more homogenous (no more `/home/pi` vs `/home/dietpi`).
