### PR TITLE
Revert to Python 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,10 +26,10 @@ jobs:
       - name: Checkout pynab
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.7
 
       - name: Set up Rust
         uses: hecrj/setup-rust-action@v1

--- a/nabmastodond/tests/nabmastodond_views_test.py
+++ b/nabmastodond/tests/nabmastodond_views_test.py
@@ -100,7 +100,7 @@ class TestView(TestCase):
 
         response = c.post(
             "/nabmastodond/connect",
-            {"location": "http://10.10.10.42/", "instance": "mstdn.fr"},
+            {"location": "http://10.10.10.42/", "instance": "mamot.fr"},
         )
         response_json = response.json()
         self.assertTrue("status" in response_json)


### PR DESCRIPTION
Support for python 3.9 is partial. Typically, snips binaries are not available
for this version of Python. As the only supported version of Raspberry Pi is
Buster and it is bundled with python 3.7, tests should be run on 3.7.

Fix #333