### PR TITLE
Reboot to switch between RFID cards

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ pyalsaaudio==0.9.0; sys_platform == 'linux'
 rpi-ws281x==4.3.3; sys_platform == 'linux' and ('armv6l' in platform_machine or 'armv7l' in platform_machine or 'aarch64' in platform_machine)
 RPi.GPIO==0.7.1; sys_platform == 'linux' and ('armv6l' in platform_machine or 'armv7l' in platform_machine or 'aarch64' in platform_machine)
 snips-nlu==0.20.2
+smbus2==0.4.1
 
 # Pre-built binaries
 https://github.com/pguyot/py-kaldi-asr/releases/download/v0.5.3/py_kaldi_asr-0.5.3-cp37-cp37m-linux_armv6l.whl; sys_platform == 'linux' and 'armv6l' in platform_machine and python_version == '3.7'


### PR DESCRIPTION
Nabboot checks for the presence of RFID devices. If there isn't any, the problem may be that the proper overlay is not enabled (or a conflict of overlays). Therefore, nabboot probes the I2C address 0x50 (unfortunately, the two cards use the same) to find out which card is connected and reconfigures /boot/config.txt accordingly.

Requires https://github.com/pguyot/cr14/pull/9