### PR TITLE
Fix obsolete Django gettext reference

### DIFF
--- a/nabweb/settings.py
+++ b/nabweb/settings.py
@@ -12,7 +12,7 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 
 import os
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))


### PR DESCRIPTION
Makes code ready for future Django version bump to `4.0.x`, where this deprecated reference will not be supported any more.

Also allows getting rid of related warnings during tests:
```
nabweb/settings.py:144
  /opt/pynab/nabweb/settings.py:144: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy()
is deprecated in favor of django.utils.translation.gettext_lazy().
```
