### PR TITLE
Fix upgrade and improve automated testing of upgrades

### DIFF
--- a/.github/workflows/test-upgrade.yml
+++ b/.github/workflows/test-upgrade.yml
@@ -2,10 +2,6 @@ name: 🛠  Test upgrade
 on:
   push:
     branches:
-      - 'releng'
-      - 'releng/*'
-      - 'release'
-      - 'master'
 
 jobs:
   test_upgrade:
@@ -20,10 +16,12 @@ jobs:
           cpu: arm1176
           cpu_info: cpuinfo/raspberrypi_zero_w
           base_image: https://github.com/nabaztag2018/pynab/releases/download/v0.9.1/pynab-v0.9.1.img.xz
+          install_dir: /home/pi/pynab
         - target: pynab_091_zero2
           cpu: cortex-a7
           cpu_info: cpuinfo/raspberrypi_zero2_w
           base_image: https://github.com/nabaztag2018/pynab/releases/download/v0.9.1/pynab-v0.9.1.img.xz
+          install_dir: /home/pi/pynab
     steps:
       - uses: actions/checkout@v2
       - name: Run test script in chroot environment
@@ -38,7 +36,7 @@ jobs:
           optimize_image: no
           import_github_env: yes
           commands: |
-            cd /home/pi/pynab
+            cd ${{ matrix.install_dir }}
             sudo -u pi git remote set-branches --add origin ${GITHUB_REF##*/}
             sudo -u pi git fetch -v
             sudo -u pi git branch release -u origin/${GITHUB_REF##*/}
@@ -49,5 +47,7 @@ jobs:
             aplay -L
             cluster_version=`echo /etc/postgresql/*/main/pg_hba.conf  | sed -E 's|/etc/postgresql/(.+)/(.+)/pg_hba.conf|\1|g'`
             cluster_name=`echo /etc/postgresql/*/main/pg_hba.conf  | sed -E 's|/etc/postgresql/(.+)/(.+)/pg_hba.conf|\2|g'`
-            sudo -u postgres /usr/lib/postgresql/${cluster_version}/bin/pg_ctl start -D /etc/postgresql/${cluster_version}/${cluster_name}/
-            sudo -u pi /bin/bash /home/pi/pynab/upgrade.sh
+            sudo -u postgres taskset -c 0 /usr/lib/postgresql/${cluster_version}/bin/pg_ctl start -D /etc/postgresql/${cluster_version}/${cluster_name}/
+            sudo -u pi /bin/bash upgrade.sh
+            sudo mkdir -p /run/systemd/timesync/ && sudo touch /run/systemd/timesync/synchronized
+            CI=1 venv/bin/pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,8 @@ jobs:
         run: |
           sudo apt update -y
           sudo apt-get install -y libasound2-dev libmpg123-dev libatlas-base-dev curl
+          wget -q -O install_mkl.sh https://raw.githubusercontent.com/pguyot/kaldi/e4940d045d39deb86016bc176893303b5240ff59/tools/extras/install_mkl.sh
+          sudo bash install_mkl.sh
           wget -q -O - "https://github.com/pguyot/kaldi/releases/download/e4940d045/kaldi-e4940d045-linux_ubuntu20.04-x86_64.tar.xz" | sudo tar xJ -C /
           sudo ldconfig
           python -m pip install --upgrade pip
@@ -51,6 +53,12 @@ jobs:
 
       - name: Install requirements
         run: pip install -r requirements.txt
+
+      - name: Install kaldi models
+        run: |
+          sudo mkdir -p /opt/kaldi/model/
+          sudo tar xJf asr/kaldi-nabaztag-en-adapt-r20191222.tar.xz -C /opt/kaldi/model/
+          sudo tar xJf asr/kaldi-nabaztag-fr-adapt-r20200203.tar.xz -C /opt/kaldi/model/
 
       - name: Setup PostgreSQL database
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           sudo apt update -y
           sudo apt-get install -y libasound2-dev libmpg123-dev libatlas-base-dev curl
-          wget -q -O - "https://github.com/pguyot/kaldi/releases/download/v5.4.1/kaldi-c3260f2-linux_x86_64-vfp.tar.xz" | sudo tar xJ -C /
+          wget -q -O - "https://github.com/pguyot/kaldi/releases/download/e4940d045/kaldi-e4940d045-linux_ubuntu20.04-x86_64.tar.xz" | sudo tar xJ -C /
           sudo ldconfig
           python -m pip install --upgrade pip
           pip install cython numpy setuptools_rust wheel

--- a/install.sh
+++ b/install.sh
@@ -211,9 +211,12 @@ if [ $makerfaire2018 -eq 0 ]; then
     sudo ldconfig
 
     # Fix upgrade of py-kaldi-asr
-    [ -e ${root_dir}venv/lib/python3.7/site-packages/kaldiasr/nnet3.cpython-37m-arm-linux-gnueabihf.so ] \
-        && grep -c ZN3fst8internal14DenseSymbolMapD1Ev ${root_dir}venv/lib/python3.7/site-packages/kaldiasr/nnet3.cpython-37m-arm-linux-gnueabihf.so \
-        && venv/bin/pip uninstall -y py-kaldi-asr
+    pushd ${root_dir}
+    if [[ -f venv/lib/python3.7/site-packages/kaldiasr/nnet3.cpython-37m-arm-linux-gnueabihf.so && "$(grep -c ZN3fst8internal14DenseSymbolMapD1Ev venv/lib/python3.7/site-packages/kaldiasr/nnet3.cpython-37m-arm-linux-gnueabihf.so)" -ne 0 ]]; then
+        echo "Removing incompatible py-kaldi-asr package"
+        venv/bin/pip uninstall -y py-kaldi-asr
+    fi
+    popd
   fi
 
   sudo mkdir -p "${kaldi_dir}/model"

--- a/nabclockd/tests/nabclockd_test.py
+++ b/nabclockd/tests/nabclockd_test.py
@@ -333,6 +333,7 @@ class TestNabclockd(NabdMockTestCase):
         setattr(config, "wakeup_min_" + dayOfTheWeek, wakeup_min)
         setattr(config, "sleep_hour_" + dayOfTheWeek, sleep_hour)
         setattr(config, "sleep_min_" + dayOfTheWeek, sleep_min)
+        config.chime_hour = False
         config.save()
         service = self.create_service()
         this_loop.call_later(1, lambda: self._update_wakeup_hours(service))

--- a/nabd/tests/asr_test.py
+++ b/nabd/tests/asr_test.py
@@ -1,0 +1,26 @@
+import os
+import platform
+import sys
+import unittest
+
+import pytest
+
+from nabd.asr import ASR
+
+
+@pytest.mark.skipif(
+    "CI" in os.environ
+    and sys.platform == "linux"
+    and "x86_64" in platform.machine(),
+    reason="Kaldi currently crashes in GitHub CI",
+)
+class TestASR(unittest.TestCase):
+    def test_get_model(self):
+        self.assertEqual("fr_FR", ASR.get_locale("fr_FR"))
+        self.assertEqual("en_GB", ASR.get_locale("en_GB"))
+        self.assertEqual("en_US", ASR.get_locale("en_US"))
+        self.assertEqual("fr_FR", ASR.get_locale("de_DE"))
+
+    def test_load_model_fr(self):
+        asr = ASR("fr_FR")
+        self.assertTrue(asr.model is not None)


### PR DESCRIPTION
- Fix a test with nabclockd
- Add a new simple test of ASR to make sure kaldi is properly configured
- Fix upgrade logic related to py-kaldi-asr 0.5.3 binary
- Run tests in CI after upgrade
- Run test upgrade CI on every push