### PR TITLE
Keep comitup transitions silent

### DIFF
--- a/comitup-callback.sh
+++ b/comitup-callback.sh
@@ -4,13 +4,8 @@ if [ "$1" == "CONNECTED" ]; then
 	sudo systemctl restart nabairqualityd
 	sudo systemctl restart nabweatherd
 	echo '{"type":"command","sequence":[{"choreography":"nabd/vert.chor"}]}' | nc -4 -w 5 -v localhost 10543
-	echo '{"type":"command","sequence":[{"choreography":"nabtaichid/taichi.chor"}]}' | nc -4 -w 5 -v localhost 10543
-fi
-
-if [ "$1" == "HOTSPOT" ]; then
+elif [ "$1" == "HOTSPOT" ]; then
 	echo '{"type":"command","sequence":[{"choreography":"nabd/rouge.chor"}]}' | nc -4 -w 5 -v localhost 10543
-fi
-
-if [ "$1" == "CONNECTING" ]; then
+elif [ "$1" == "CONNECTING" ]; then
 	echo '{"type":"command","sequence":[{"choreography":"nabd/orange.chor"}]}' | nc -4 -w 5 -v localhost 10543
 fi


### PR DESCRIPTION
Play only visual (no sound) choreographies on comitup network state transitions, to avoid making noise if transition occurs while rabbit is asleep (avoid violating the _"rabbit should keep silent when asleep_" golden rule).