### PR TITLE
nabclockd rfid: fix localisation file

### DIFF
--- a/nabclockd/locale/fr_FR/LC_MESSAGES/django.po
+++ b/nabclockd/locale/fr_FR/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-13 08:42+0200\n"
+"POT-Creation-Date: 2022-06-21 18:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: templates/nabclockd/rfid-data.html:2
-#, fuzzy
 msgid ""
 "If you selected Sleep and want your Nabaztag to wake up, just push its head "
 "button."
@@ -101,5 +100,3 @@ msgstr "Enregistrer"
 #: templates/nabclockd/settings.html:204
 msgid "Reset"
 msgstr "Annuler"
-
-


### PR DESCRIPTION
Fix nabclockd localisation file so that _"Si vous avez sélectionné Dormir et que vous voulez réveiller votre Nabaztag il suffit d'appuyer sur le bouton du haut."_ message appears correctly if Clock application is selected on NFC page when using French locale.