### PR TITLE
nabweb: fix botched localisation file

### DIFF
--- a/nabweb/locale/fr_FR/LC_MESSAGES/django.po
+++ b/nabweb/locale/fr_FR/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-06 20:48+0000\n"
+"POT-Creation-Date: 2022-07-16 10:16+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -78,8 +78,8 @@ msgstr "NFC"
 msgid "System Information"
 msgstr "Information système"
 
-#: templates/nabweb/_base.html:36 templates/nabweb/upgrade/index.html:3
-#: templates/nabweb/upgrade/index.html:42
+#: templates/nabweb/_base.html:36 templates/nabweb/upgrade/index.html:4
+#: templates/nabweb/upgrade/index.html:53
 msgid "Upgrade"
 msgstr "Mise à jour"
 
@@ -262,8 +262,8 @@ msgid ""
 "The open heart operation to transplant the cards into your rabbit. At this "
 "stage you probably do not need this anymore..."
 msgstr ""
-"L'opération à cœur ouvert pour transplanter les cartes dans votre "
-"lapin. A ce stade, vous n'en avez probablement plus besoin ..."
+"L'opération à cœur ouvert pour transplanter les cartes dans votre lapin. A "
+"ce stade, vous n'en avez probablement plus besoin ..."
 
 #: templates/nabweb/index.html:8
 msgid "You are currently connected to your rabbit."
@@ -355,14 +355,14 @@ msgstr ""
 #: templates/nabweb/rfid/index.html:16
 #: templates/nabweb/system-info/index.html:113
 #: templates/nabweb/system-info/index.html:119
-#: templates/nabweb/upgrade/index.html:32
+#: templates/nabweb/upgrade/index.html:43
 msgid "Yes"
 msgstr "Oui"
 
 #: templates/nabweb/rfid/index.html:17
 #: templates/nabweb/system-info/index.html:113
 #: templates/nabweb/system-info/index.html:119
-#: templates/nabweb/upgrade/index.html:33
+#: templates/nabweb/upgrade/index.html:44
 msgid "No"
 msgstr "Non"
 
@@ -792,19 +792,19 @@ msgstr "Vous avez des commits locaux non publiés dans ce référentiel."
 msgid "You have local changes in this repository."
 msgstr "Vous avez des modifications locales dans ce référentiel."
 
-#: templates/nabweb/upgrade/index.html:9
+#: templates/nabweb/upgrade/index.html:11
 msgid "Upgrade in progress"
 msgstr "Mise à jour en cours"
 
-#: templates/nabweb/upgrade/index.html:16
+#: templates/nabweb/upgrade/index.html:23
 msgid "Upgrade is currently in progress..."
 msgstr "La mise à jour est en cours ..."
 
-#: templates/nabweb/upgrade/index.html:25
+#: templates/nabweb/upgrade/index.html:35
 msgid "Local changes"
 msgstr "Modifications locales"
 
-#: templates/nabweb/upgrade/index.html:28
+#: templates/nabweb/upgrade/index.html:38
 msgid ""
 "Local changes have been detected in at least one repository. Automatic "
 "upgrade may fail. Are you sure you want to proceed?"
@@ -812,29 +812,26 @@ msgstr ""
 "Des modifications locales ont été détectées dans au moins un référentiel. La "
 "mise à jour automatique risque d'échouer. Souhaitez-vous néanmoins continuer?"
 
-#: templates/nabweb/upgrade/index.html:45
+#: templates/nabweb/upgrade/index.html:57
 msgid ""
 "Through this interface, you can upgrade your Nabaztag software (provided it "
-"is connected to\n"
-"          the internet). This may take a while depending on the size and the "
-"scope of the update. <strong>Do not restart\n"
-"            your rabbit before the process is finished</strong>."
+"is connected to the internet). This may take a while depending on the size "
+"and the scope of the update. <strong>Do not restart your rabbit before the "
+"process is finished</strong>."
 msgstr ""
 "Grâce à cette interface, vous pouvez mettre à jour le logiciel de votre "
 "Nabaztag (s'il est connecté à Internet). Attention, cela peut être assez "
 "long en fonction de ce qu'il y a à faire. <strong>Attendez la fin de la mise "
 "à jour sinon on ne répond plus de rien</strong>."
 
-#: templates/nabweb/upgrade/index.html:49
+#: templates/nabweb/upgrade/index.html:61
 msgid ""
-"You can switch to the Pynab <b>master</b> branch to benefit from\n"
-"          changes between releases, however this is not for the faint-"
-"hearted and requires good command of <a\n"
-"            href='https://www.raspberrypi.org/documentation/remote-access/"
-"ssh/' target='_blank'\n"
-"            rel='noopener noreferrer'>SSH</a> and <a href='https://git-scm."
-"com/docs/' target='_blank'\n"
-"            rel='noopener noreferrer'>Git</a>."
+"You can switch to the Pynab <b>master</b> branch to benefit from changes "
+"between releases, however this is not for the faint-hearted and requires "
+"good command of <a href='https://www.raspberrypi.org/documentation/remote-"
+"access/ssh/' target='_blank' rel='noopener noreferrer'>SSH</a> and <a "
+"href='https://git-scm.com/docs/' target='_blank' rel='noopener "
+"noreferrer'>Git</a>."
 msgstr ""
 "Vous pouvez basculer sur la branche <b>master</b> de Pynab pour avoir les "
 "dernières nouveautés, mais ceci suppose que vous n'avez pas peur de <a "
@@ -842,44 +839,42 @@ msgstr ""
 "target='_blank' rel='noopener noreferrer'>SSH</a> et de <a href='https://git-"
 "scm.com/docs/' target='_blank' rel='noopener noreferrer'>Git</a>."
 
-#: templates/nabweb/upgrade/index.html:55
+#: templates/nabweb/upgrade/index.html:65
 msgid ""
-"Your Nabaztag is using a purely local Pynab branch. Upgrade is not\n"
-"          applicable."
+"Your Nabaztag is using a purely local Pynab branch. Upgrade is not "
+"applicable."
 msgstr ""
 "Votre Nabaztag utilise une branche purement locale de Pynab. Pas de mise à "
 "jour dans ce cas."
 
-#: templates/nabweb/upgrade/index.html:58
+#: templates/nabweb/upgrade/index.html:69
 msgid ""
-"Your Nabaztag is apparently not tracking the Pynab <b>release</b>\n"
-"          branch. Please note that web-based upgrade mechanism may fail and "
-"require that you connect over\n"
-"          SSH."
+"Your Nabaztag is apparently not tracking the Pynab <b>release</b> branch. "
+"Please note that web-based upgrade mechanism may fail and require that you "
+"connect over SSH."
 msgstr ""
 "Attention, apparemment, votre Nabaztag ne suit pas la branche <b>release</b> "
 "de Pynab : la mise à jour avec l'interface web peut échouer. Et là, que la "
 "force soit avec vous, il faudra terminer en SSH."
 
-#: templates/nabweb/upgrade/index.html:62
+#: templates/nabweb/upgrade/index.html:72
 msgid "Current versions"
 msgstr "Versions actuelles"
 
-#: templates/nabweb/upgrade/index.html:90
+#: templates/nabweb/upgrade/index.html:100
 msgid "Last check:"
 msgstr "Dernière vérification :"
 
-#: templates/nabweb/upgrade/index.html:91
+#: templates/nabweb/upgrade/index.html:101
 #, python-format
-#| msgid "%(last_check_since) ago"
 msgid "%(last_check_since)s ago"
 msgstr "il y a %(last_check_since)s"
 
-#: templates/nabweb/upgrade/index.html:96
+#: templates/nabweb/upgrade/index.html:107
 msgid "Check now"
 msgstr "Vérifier maintenant"
 
-#: templates/nabweb/upgrade/index.html:100
+#: templates/nabweb/upgrade/index.html:113
 msgid "Upgrade now"
 msgstr "Mettre à jour"
 

--- a/nabweb/templates/nabweb/upgrade/index.html
+++ b/nabweb/templates/nabweb/upgrade/index.html
@@ -54,25 +54,19 @@
                 </div>
                 <div class="card-body">
                     <p>
-                        {% blocktrans %}Through this interface, you can upgrade your Nabaztag software (provided it is connected to
-          the internet). This may take a while depending on the size and the scope of the update. <strong>Do not restart
-            your rabbit before the process is finished</strong>.{% endblocktrans %}
+                        {% blocktrans %}Through this interface, you can upgrade your Nabaztag software (provided it is connected to the internet). This may take a while depending on the size and the scope of the update. <strong>Do not restart your rabbit before the process is finished</strong>.{% endblocktrans %}
                     </p>
                     {% if pynab.upstream_branch == "origin/release" %}
                         <p class="text-secondary">
-                            {% blocktrans %}You can switch to the Pynab <b>master</b> branch to benefit from
-          changes between releases, however this is not for the faint-hearted and requires good command of <a href='https://www.raspberrypi.org/documentation/remote-access/ssh/' target='_blank' rel='noopener noreferrer'>SSH</a> and <a href='https://git-scm.com/docs/' target='_blank' rel='noopener noreferrer'>Git</a>.{% endblocktrans %}
+                            {% blocktrans %}You can switch to the Pynab <b>master</b> branch to benefit from changes between releases, however this is not for the faint-hearted and requires good command of <a href='https://www.raspberrypi.org/documentation/remote-access/ssh/' target='_blank' rel='noopener noreferrer'>SSH</a> and <a href='https://git-scm.com/docs/' target='_blank' rel='noopener noreferrer'>Git</a>.{% endblocktrans %}
                         </p>
                     {% elif pynab.upstream_branch == "" %}
                         <p class="text-warning">
-                            {% blocktrans %}Your Nabaztag is using a purely local Pynab branch. Upgrade is not
-          applicable.{% endblocktrans %}
+                            {% blocktrans %}Your Nabaztag is using a purely local Pynab branch. Upgrade is not applicable.{% endblocktrans %}
                         </p>
                     {% else %}
                         <p class="text-warning">
-                            {% blocktrans %}Your Nabaztag is apparently not tracking the Pynab <b>release</b>
-          branch. Please note that web-based upgrade mechanism may fail and require that you connect over
-          SSH.{% endblocktrans %}
+                            {% blocktrans %}Your Nabaztag is apparently not tracking the Pynab <b>release</b> branch. Please note that web-based upgrade mechanism may fail and require that you connect over SSH.{% endblocktrans %}
                         </p>
                     {% endif %}
                     <h5>{% trans "Current versions" %}</h5>


### PR DESCRIPTION
Restore proper localisation of
"_You can switch to the Pynab master branch to benefit from changes between releases, however this is not for the faint-hearted ..._"
message on upgrade page.