### PR TITLE
nabd: allow running without TagTagTag card

### DIFF
--- a/nabd/nabio.py
+++ b/nabd/nabio.py
@@ -22,6 +22,8 @@ class NabIO(object, metaclass=abc.ABCMeta):
     MODEL_2019_TAGTAG = 3
     # with NFC card
     MODEL_2022_NFC = 4
+    # no TagTagTag card
+    MODEL_NONE = 5
 
     # Each info loop lasts 15 seconds
     INFO_LOOP_LENGTH = 15.0


### PR DESCRIPTION
Allow `nabd` to run (without constantly failing/restarting) when no TagTagTag card is detected (albeit in a degraded state: no sound input/output, no LEDs nor ears, no RFID).
This allows all services to be fully operational (within these constraints), together with the web interface.