### PR TITLE
comitup callback: disable NabBlockly when in hotspot state

### DIFF
--- a/comitup-callback.sh
+++ b/comitup-callback.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
 if [ "$1" == "CONNECTED" ]; then
-	sudo systemctl restart nabairqualityd
-	sudo systemctl restart nabweatherd
+	systemctl is-active --quiet nabairqualityd && sudo systemctl kill -s SIGUSR1 nabairqualityd
+	systemctl is-active --quiet nabweatherd && sudo systemctl kill -s SIGUSR1 nabweatherd
+	systemctl is-enabled --quiet nabblockly && sudo systemctl start nabblockly
 	echo '{"type":"command","sequence":[{"choreography":"nabd/vert.chor"}]}' | nc -4 -w 5 -v localhost 10543
 elif [ "$1" == "HOTSPOT" ]; then
+	systemctl is-enabled --quiet nabblockly && sudo systemctl stop nabblockly
 	echo '{"type":"command","sequence":[{"choreography":"nabd/rouge.chor"}]}' | nc -4 -w 5 -v localhost 10543
 elif [ "$1" == "CONNECTING" ]; then
 	echo '{"type":"command","sequence":[{"choreography":"nabd/orange.chor"}]}' | nc -4 -w 5 -v localhost 10543


### PR DESCRIPTION
- Disable NabBlockly when in hotspot state, to avoid possible confusion (user connecting to hotspot on port 8080).
- Also avoid full restart of services that depend on Internet access.