### PR TITLE
Upgrade GitHub workflows to new GitHub requirements & add missing labels for PR labeler workflow

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -64,8 +64,14 @@
 'Service: Weather':
   - nabweatherd/**
 
-'Service: Nabiftttd':
+'Service: IFTTT':
   - nabiftttd/**
+
+'Service: Radio':
+  - nabradio/**
+
+'Service: Web hook':
+  - nabwebhook/**
 
 'web':
   - nabweb/**

--- a/.github/workflows/arm-runner.yml
+++ b/.github/workflows/arm-runner.yml
@@ -34,7 +34,7 @@ jobs:
           base_image: raspios_lite_arm64:latest
     steps:
       - name: Checkout pynab
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run test suite in chroot environment
         uses: pguyot/arm-runner-action@v2
@@ -88,30 +88,30 @@ jobs:
           base_image: raspios_lite_arm64:latest
     steps:
       - name: Checkout pynab
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Define the image name
         id: image_and_branch_name
         run: |
           if [ ${GITHUB_REF/refs\/tags\//} != ${GITHUB_REF} ]; then
-            echo ::set-output name=LOCAL_BRANCH::${GITHUB_REF/refs\/tags\//}
-            echo ::set-output name=RELEASE_NAME::${GITHUB_REF/refs\/tags\//}
-            echo ::set-output name=IMAGE_NAME_SUFFIX::${GITHUB_REF/refs\/tags\//}-${{ matrix.target }}
-            echo ::set-output name=CLONE_RELEASE::yes
+            echo "LOCAL_BRANCH=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+            echo "RELEASE_NAME=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+            echo "IMAGE_NAME_SUFFIX=${GITHUB_REF/refs\/tags\//}-${{ matrix.target }}" >> $GITHUB_OUTPUT
+            echo "CLONE_RELEASE=yes" >> $GITHUB_OUTPUT
           elif [ ${GITHUB_REF/refs\/heads\//} = "releng" ]; then
-            echo ::set-output name=LOCAL_BRANCH::releng
-            echo ::set-output name=RELEASE_NAME::releng
-            echo ::set-output name=IMAGE_NAME_SUFFIX::releng-${{ matrix.target }}
-            echo ::set-output name=CLONE_RELEASE::yes
+            echo "LOCAL_BRANCH=releng" >> $GITHUB_OUTPUT
+            echo "RELEASE_NAME=releng" >> $GITHUB_OUTPUT
+            echo "IMAGE_NAME_SUFFIX=releng-${{ matrix.target }}" >> $GITHUB_OUTPUT
+            echo "CLONE_RELEASE=yes" >> $GITHUB_OUTPUT
           elif [ ${GITHUB_REF/refs\/heads\//} != "${GITHUB_REF}" ]; then
-            echo ::set-output name=LOCAL_BRANCH::${GITHUB_REF/refs\/heads\//}
-            echo ::set-output name=RELEASE_NAME::${GITHUB_REF/refs\/heads\//}
-            echo ::set-output name=IMAGE_NAME_SUFFIX::${GITHUB_REF/refs\/heads\//}-${{ matrix.target }}
-            echo ::set-output name=CLONE_RELEASE::yes
+            echo "LOCAL_BRANCH=${GITHUB_REF/refs\/heads\//}" >> $GITHUB_OUTPUT
+            echo "RELEASE_NAME=${GITHUB_REF/refs\/heads\//}" >> $GITHUB_OUTPUT
+            echo "IMAGE_NAME_SUFFIX=${GITHUB_REF/refs\/heads\//}-${{ matrix.target }}" >> $GITHUB_OUTPUT
+            echo "CLONE_RELEASE=yes" >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=LOCAL_BRANCH::${GITHUB_REF}
-            echo ::set-output name=IMAGE_NAME_SUFFIX::${GITHUB_REF//\//-}-${{ matrix.target }}
-            echo ::set-output name=CLONE_RELEASE::no
+            echo "LOCAL_BRANCH=${GITHUB_REF}" >> $GITHUB_OUTPUT
+            echo "IMAGE_NAME_SUFFIX=${GITHUB_REF//\//-}-${{ matrix.target }}" >> $GITHUB_OUTPUT
+            echo "CLONE_RELEASE=no" >> $GITHUB_OUTPUT
           fi
 
       - name: Create a release image in chroot environment
@@ -153,7 +153,7 @@ jobs:
           sudo xz -T 0 -v pynab-${{ steps.image_and_branch_name.outputs.IMAGE_NAME_SUFFIX }}.img
 
       - name: Upload the image artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: pynab-${{ steps.image_and_branch_name.outputs.IMAGE_NAME_SUFFIX }}.img.xz
           path: pynab-${{ steps.image_and_branch_name.outputs.IMAGE_NAME_SUFFIX }}.img.xz
@@ -172,19 +172,19 @@ jobs:
         id: release_name
         run: |
           if [ ${GITHUB_REF/refs\/tags\//} != ${GITHUB_REF} ]; then
-             echo ::set-output name=RELEASE_NAME::${GITHUB_REF/refs\/tags\//}
+             echo "RELEASE_NAME=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
           elif [ ${GITHUB_REF/refs\/heads\//} = "releng" ]; then
-             echo ::set-output name=RELEASE_NAME::releng
+             echo "RELEASE_NAME=releng" >> $GITHUB_OUTPUT
           else
-             echo ::set-output name=RELEASE_NAME::${GITHUB_REF/refs\/heads\//}
+             echo "RELEASE_NAME=${GITHUB_REF/refs\/heads\//}" >> $GITHUB_OUTPUT
           fi
 
       - name: Download the image artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
 
       - name: Create release with releng image
         if: github.ref == 'refs/heads/releng'
-        uses: "marvinpinto/action-automatic-releases@v1.1.2"
+        uses: "marvinpinto/action-automatic-releases@v1.2.1"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "latest"
@@ -195,7 +195,7 @@ jobs:
 
       - name: Create release with release image
         if: startsWith(github.ref, 'refs/tags/')
-        uses: "marvinpinto/action-automatic-releases@v1.1.2"
+        uses: "marvinpinto/action-automatic-releases@v1.2.1"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: ${{ steps.release_name.outputs.RELEASE_NAME }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Apply labels
-        uses: actions/labeler@v3
+        uses: actions/labeler@v4
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/labels.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - name: Checkout pynab
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 


### PR DESCRIPTION
See:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Also add missing labels for PR labeler workflow.