### PR TITLE
Force kernel 5.15.32 on Bullseye images

### DIFF
--- a/setup
+++ b/setup
@@ -170,7 +170,31 @@ echo "Installing required packages."
 sudo apt-get update -y
 sudo apt-get dist-upgrade -y
 sudo apt-get install --no-install-recommends -y postgresql libpq-dev git python3 python3-venv python3-dev gettext nginx openssl libssl-dev libffi-dev libmpg123-dev libasound2-dev libatlas-base-dev libgfortran5 libopenblas-dev liblapack-dev zram-tools
-sudo apt-get install --no-install-recommends -y gcc make raspberrypi-kernel-headers
+sudo apt-get install --no-install-recommends -y gcc make
+os_version=$(. /etc/os-release && echo "$VERSION_ID")
+if [ "${os_version}" == "11"  ]
+then
+    # Bullseye (nasty) patch: force rollback to kernel 5.15.32 (20220331)
+    # since wm8960 driver is incompatible with later versions.
+    kver="1.20220331-1"
+    if [ "$(uname -m)" == "aarch64" ]
+    then
+        karch="arm64"
+    else
+        karch="armhf"
+    fi
+    cd /tmp
+    wget https://archive.raspberrypi.org/debian/pool/main/r/raspberrypi-firmware/raspberrypi-kernel_${kver}_${karch}.deb
+    sudo dpkg -i raspberrypi-kernel_${kver}_${karch}.deb
+    rm raspberrypi-kernel_${kver}_${karch}.deb
+    sudo apt-mark hold raspberrypi-kernel
+    wget https://archive.raspberrypi.org/debian/pool/main/r/raspberrypi-firmware/raspberrypi-kernel-headers_${kver}_${karch}.deb
+    sudo dpkg -i raspberrypi-kernel-headers_${kver}_${karch}.deb
+    rm raspberrypi-kernel-headers_${kver}_${karch}.deb
+    sudo apt-mark hold raspberrypi-kernel-headers
+else
+    sudo apt-get install --no-install-recommends -y raspberrypi-kernel-headers
+fi
 
 build_and_install_driver() {
     for dir in /lib/modules/*/build

--- a/setup
+++ b/setup
@@ -108,9 +108,9 @@ cat /boot/config.txt | grep "dtoverlay=hifiberry-dac"
 if [ "${install_env}" == "ci-chroot" ]
 then
     # Install comitup package for headless WiFi setup
-    wget https://davesteele.github.io/comitup/deb/davesteele-comitup-apt-source_1.1_all.deb
-    dpkg -i --force-all davesteele-comitup-apt-source_1.1_all.deb
-    rm davesteele-comitup-apt-source_1.1_all.deb
+    wget https://davesteele.github.io/comitup/deb/davesteele-comitup-apt-source_1.2_all.deb
+    dpkg -i --force-all davesteele-comitup-apt-source_1.2_all.deb
+    rm davesteele-comitup-apt-source_1.2_all.deb
     apt-get update -y
     apt-get install --no-install-recommends -y comitup comitup-watch
     rm /etc/network/interfaces
@@ -119,6 +119,7 @@ then
     systemctl mask dhcpd.service
     systemctl mask dhcpcd.service
     systemctl mask wpa-supplicant.service
+    systemctl enable NetworkManager.service
     echo "web_service: nginx.service" >> /etc/comitup.conf
     echo "ap_name: Nabaztag-<nnn>" >> /etc/comitup.conf
     echo "service_name: Nabaztag" >> /etc/comitup.conf


### PR DESCRIPTION
Resolves #438  (sort of).

Force installation of kernel version 5.15.32 (rather than later versions) on Bullseye-based Pynab images.
This allows generating functional Pynab images with a working sound driver and is intended as a temporary workaround till https://github.com/pguyot/wm8960/issues/21 is properly fixed.

Also includes comitup setup fix from #440.