### PR TITLE
GitHub workflows: use raspios_lite:2023-05-03 base image

### DIFF
--- a/.github/workflows/arm-runner.yml
+++ b/.github/workflows/arm-runner.yml
@@ -23,7 +23,7 @@ jobs:
         - target: zero_raspios
           cpu: arm1176
           cpu_info: cpuinfo/raspberrypi_zero_w
-          base_image: raspios_lite:latest
+          base_image: raspios_lite:2023-05-03
         - target: zero_dietpi
           cpu: arm1176
           cpu_info: cpuinfo/raspberrypi_zero_w
@@ -31,7 +31,7 @@ jobs:
         - target: zero2_64_raspios
           cpu: cortex-a53
           cpu_info: cpuinfo/raspberrypi_zero2_w_arm64
-          base_image: raspios_lite_arm64:latest
+          base_image: raspios_lite_arm64:2023-05-03
     steps:
       - name: Checkout pynab
         uses: actions/checkout@v3
@@ -77,7 +77,7 @@ jobs:
         - target: zero_raspios
           cpu: arm1176
           cpu_info: cpuinfo/raspberrypi_zero_w
-          base_image: raspios_lite:latest
+          base_image: raspios_lite:2023-05-03
         - target: zero_dietpi
           cpu: arm1176
           cpu_info: cpuinfo/raspberrypi_zero_w
@@ -85,7 +85,7 @@ jobs:
         - target: zero2_64_raspios
           cpu: cortex-a53
           cpu_info: cpuinfo/raspberrypi_zero2_w_arm64
-          base_image: raspios_lite_arm64:latest
+          base_image: raspios_lite_arm64:2023-05-03
     steps:
       - name: Checkout pynab
         uses: actions/checkout@v3


### PR DESCRIPTION
 This ensures that a Bullseye (**not** Bookworm) image is used when building the _raspios_ images.

**Note**: a prerequisite for this PR is that GitHub action _arm-runner-action@v2_ is bumped to at least https://github.com/pguyot/arm-runner-action/commit/c1cc33008fbd0ecd170ff18b8d574ff97d75864e (so that it knows about this base image).