### PR TITLE
nabweb: Upgrade page Version: always show commit even if no tags

### DIFF
--- a/nabweb/views.py
+++ b/nabweb/views.py
@@ -599,8 +599,8 @@ class GitInfo:
             info["local_commits_count"] = int(local_commits_count)
         info["tag"] = (
             os.popen(
-                f"git -C {repo_dir} describe --long 2>/dev/null || "
-                f"git -C {repo_dir} describe --long --tags 2>/dev/null"
+                f"git -C {repo_dir} describe --long --tags --always "
+                f"2>/dev/null"
             )
             .read()
             .strip()


### PR DESCRIPTION
Avoid having no version displayed if there are no "visible" tags in local (shallow) repository.