### PR TITLE
setup: remove kernel rollback patch

### DIFF
--- a/setup
+++ b/setup
@@ -170,31 +170,7 @@ echo "Installing required packages."
 sudo apt-get update -y
 sudo apt-get dist-upgrade -y
 sudo apt-get install --no-install-recommends -y postgresql libpq-dev git python3 python3-venv python3-dev gettext nginx openssl libssl-dev libffi-dev libmpg123-dev libasound2-dev libatlas-base-dev libgfortran5 libopenblas-dev liblapack-dev zram-tools
-sudo apt-get install --no-install-recommends -y gcc make
-os_version=$(. /etc/os-release && echo "$VERSION_ID")
-if [ "${os_version}" == "11"  ]
-then
-    # Bullseye (nasty) patch: force rollback to kernel 5.15.32 (20220331)
-    # since wm8960 driver is incompatible with later versions.
-    kver="1.20220331-1"
-    if [ "$(uname -m)" == "aarch64" ]
-    then
-        karch="arm64"
-    else
-        karch="armhf"
-    fi
-    cd /tmp
-    wget https://archive.raspberrypi.org/debian/pool/main/r/raspberrypi-firmware/raspberrypi-kernel_${kver}_${karch}.deb
-    sudo dpkg -i raspberrypi-kernel_${kver}_${karch}.deb
-    rm raspberrypi-kernel_${kver}_${karch}.deb
-    sudo apt-mark hold raspberrypi-kernel
-    wget https://archive.raspberrypi.org/debian/pool/main/r/raspberrypi-firmware/raspberrypi-kernel-headers_${kver}_${karch}.deb
-    sudo dpkg -i raspberrypi-kernel-headers_${kver}_${karch}.deb
-    rm raspberrypi-kernel-headers_${kver}_${karch}.deb
-    sudo apt-mark hold raspberrypi-kernel-headers
-else
-    sudo apt-get install --no-install-recommends -y raspberrypi-kernel-headers
-fi
+sudo apt-get install --no-install-recommends -y gcc make raspberrypi-kernel-headers
 
 build_and_install_driver() {
     for dir in /lib/modules/*/build


### PR DESCRIPTION
Since issue https://github.com/pguyot/wm8960/issues/21 with sound driver on recent kernels is now fixed, **setup** patch to force kernel rollback to version 5.15.32 may be removed.