### PR TITLE
Update Kaldi release

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -190,7 +190,7 @@ if [ $makerfaire2018 -eq 0 ]; then
   fi
 
   # Maker Faire card has no mic, no need to install Kaldi
-  kaldi_release="e4940d045"
+  kaldi_release="0ff452b"
   kaldi_dir="/opt/kaldi"; kaldi_pkgconfig="/usr/lib/pkgconfig/kaldi-asr.pc"
   if [[ -f "${kaldi_pkgconfig}" && "$(grep -c ${kaldi_release} ${kaldi_pkgconfig})" -eq 0 ]]; then
      # Installed Kaldi does not match needed version: remove it


### PR DESCRIPTION
This pull request updates the Kaldi release to version 0ff452b, the previous release e4940d045 did not include raspbian12.

https://github.com/pguyot/kaldi/releases/tag/0ff452b

Since the new release is based on e4940d045, this should not break the current pynab/older versions.