### PR TITLE
Add missing 'Bancs de Brouillard' weather class.

### DIFF
--- a/nabweatherd/nabweatherd.py
+++ b/nabweatherd/nabweatherd.py
@@ -207,6 +207,10 @@ class NabWeatherd(NabInfoService):
             "foggy",
             FOGGY_INFO_ANIMATION,
         ),
+        "Bancs de Brouillard": (
+            "foggy",
+            FOGGY_INFO_ANIMATION,
+        ),
         "Brouillard": (
             "foggy",
             FOGGY_INFO_ANIMATION,


### PR DESCRIPTION
Avoid **nabweatherd** crash because of missing weather class (new _Météo France_ class?)
See https://www.tagtagtag.fr/forum/showthread.php?tid=528.